### PR TITLE
Override for angular-xeditable 0.1.8

### DIFF
--- a/package-overrides/github/vitalets/angular-xeditable@0.1.8.json
+++ b/package-overrides/github/vitalets/angular-xeditable@0.1.8.json
@@ -1,0 +1,3 @@
+{
+  "main": "dist/js/xeditable.min"
+}


### PR DESCRIPTION
Added override for angular-editable 0.1.8

Testable using:

```
jspm install github:vitalets/angular-xeditable -o '{main: "dist/js/xeditable.min"}'
```
