### PR TITLE
Switch lodash from npm:lodash-node to npm:lodash

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -33,7 +33,7 @@
   "jquery.cookie": "github:carhartl/jquery-cookie",
   "kickstrap": "github:ajkochanowicz/Kickstrap",
   "less": "github:matthewp/plugin-less",
-  "lodash": "npm:lodash-node",
+  "lodash": "npm:lodash",
   "marionette": "github:marionettejs/backbone.marionette",
   "masonry": "github:desandro/masonry",
   "meld": "github:cujojs/meld",


### PR DESCRIPTION
I think `npm:lodash` is a more appropriate default for use in browser oriented js. `lodash-node` has each function in a separate file, which causes a ton of unnecessary traffic if you're using the utility normally. Even when you bundle it, each function gets its own `System.register` block. Hope I did this right! Thanks!
