### PR TITLE
Create bower-angular-mocks@1.3.0-beta.19.json

### DIFF
--- a/package-overrides/github/angular/bower-angular-mocks@1.3.0-beta.19.json
+++ b/package-overrides/github/angular/bower-angular-mocks@1.3.0-beta.19.json
@@ -1,0 +1,11 @@
+{
+  "main": "angular-mocks",
+  "shim": {
+    "angular-mocks": {
+      "deps": ["angular"]
+    }
+  },
+  "dependencies": {
+    "angular": "1.3.0-beta.19"
+  }
+}


### PR DESCRIPTION
Package override for bower-angular-mocks@1.3.0-beta.19

Info: For some reason jspm doesn't download automatically the angular dependency if I run `jspm install angular-mocks@1.3.0-beta.19`
