### PR TITLE
Use react from npm instead of github

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -57,7 +57,7 @@
   "ratchet": "github:maker/ratchet",
   "raphael": "github:DmitryBaranovskiy/raphael",
   "reqwest": "github:ded/reqwest",
-  "react": "github:reactjs/react-bower",
+  "react": "npm:react",
   "respond": "github:scottjehl/Respond",
   "rest": "github:cujojs/rest",
   "select2": "github:ivaynberg/select2",


### PR DESCRIPTION
In all projects and examples using jspm I always have issues installing react.  Perhaps there is something wrong with the package override for react-bower.

``` bash
» jspm install react
     Looking up react in registry
     Checking versions for github:reactjs/react-bower
     Downloading github:reactjs/react-bower@0.11.1

err  AssertionError: path must be a string
         at Module.require (module.js:362:3)
         at require (module.js:380:17)
         at Object.exports.loadEndpoint (/usr/local/lib/node_modules/jspm/lib/package.js:71:39)
         at /usr/local/lib/node_modules/jspm/lib/package.js:364:30
         at $$$internal$$initializePromise (/usr/local/lib/node_modules/jspm/node_modules/rsvp/dist/rsvp.js:517:9)
         at new $$rsvp$promise$$Promise (/usr/local/lib/node_modules/jspm/node_modules/rsvp/dist/rsvp.js:828:9)
         at Promise.all.then.pjson (/usr/local/lib/node_modules/jspm/lib/package.js:362:16)
         at $$$internal$$tryCatch (/usr/local/lib/node_modules/jspm/node_modules/rsvp/dist/rsvp.js:470:16)
         at $$$internal$$invokeCallback (/usr/local/lib/node_modules/jspm/node_modules/rsvp/dist/rsvp.js:482:17)
         at $$$internal$$publish (/usr/local/lib/node_modules/jspm/node_modules/rsvp/dist/rsvp.js:453:11)

err  Unable to load endpoint github
```

To fix this I always do `jspm install react=npm:react` as this works very well.

Can we just make that the default?
