### PR TITLE
add: override for bower-angular-cookies 1.3.0-rc.1

### DIFF
--- a/package-overrides/github/angular/bower-angular-cookies@1.3.0-rc.1.json
+++ b/package-overrides/github/angular/bower-angular-cookies@1.3.0-rc.1.json
@@ -1,0 +1,3 @@
+{
+  "main": "angular-cookies"
+}

--- a/registry.json
+++ b/registry.json
@@ -9,6 +9,7 @@
   "ace": "github:ajaxorg/ace-builds",
   "angular": "github:angular/bower-angular",
   "angular-mocks": "github:angular/bower-angular-mocks",
+  "angular-cookies": "github:angular/bower-angular-cookies",
   "angularFire": "github:firebase/angularFire",
   "backbone": "npm:backbone",
   "backbone.babysitter": "github:marionettejs/backbone.babysitter",


### PR DESCRIPTION
not exactly sure, if i should have included `angular` as a dependency .. like e.g. the `angular-mocks` override does, which would then look like:

```
{
  "main": "angular-cookies",
  "shim": {
    "angular-cookies": {
      "deps": ["angular"]
    }
  },
  "dependencies": {
    "angular": "1.3.0-rc.1"
  }
}
```

my local test with `jspm install github:angular/bower-angular-cookies -o "{ main: 'angular-cookies' }"` worked though.
