### PR TITLE
Create di.js@master

### DIFF
--- a/package-overrides/github/angular/di.js@master
+++ b/package-overrides/github/angular/di.js@master
@@ -1,0 +1,7 @@
+{
+  "main": "index",
+  "directories": {
+    "lib": "src"
+  },
+  "format": "es6"
+}


### PR DESCRIPTION
Package override for di.js

@guybedford Not sure how I can include the LICENSE file when defining a `lib` folder. But the whole project contains too many files which are not needed. Basically just the `src/` folder is required.

Would it be possible to support also a `files` property in the `package.json` to selectively define files which shall be also included in the stripped down package?
