### PR TITLE
add: new angular-material overrides 0.0.3 and (in foresight) 0.0.4

### DIFF
--- a/package-overrides/github/angular/bower-material@0.0.3.json
+++ b/package-overrides/github/angular/bower-material@0.0.3.json
@@ -1,0 +1,17 @@
+{
+  "main": "angular-material",
+  "shim": {
+    "angular-material": {
+      "deps": ["angular"]
+    }
+  },
+  "registry": "jspm",
+  "dependencies": {
+    "angular": "^1.3.0-rc.1",
+    "angular-animate": "^1.3.0-rc.1",
+    "hammer": "^2.0.3"
+  },
+  "buildConfig": {
+    "minify": true
+  }
+}

--- a/package-overrides/github/angular/bower-material@0.0.4.json
+++ b/package-overrides/github/angular/bower-material@0.0.4.json
@@ -1,0 +1,17 @@
+{
+  "main": "angular-material",
+  "shim": {
+    "angular-material": {
+      "deps": ["angular"]
+    }
+  },
+  "registry": "jspm",
+  "dependencies": {
+    "angular": "^1.3.0-rc.1",
+    "angular-animate": "^1.3.0-rc.1",
+    "hammer": "^2.0.3"
+  },
+  "buildConfig": {
+    "minify": true
+  }
+}


### PR DESCRIPTION
regarding https://github.com/jspm/registry/issues/11 ... here are two new 0.0.x overrides.
