### PR TITLE
Add Sentry's raven-js client to registry

### DIFF
--- a/package-overrides/github/getsentry/raven-js@1.1.16.json
+++ b/package-overrides/github/getsentry/raven-js@1.1.16.json
@@ -1,0 +1,3 @@
+{
+	"main": "dist/raven.min"
+}

--- a/registry.json
+++ b/registry.json
@@ -76,6 +76,7 @@
   "quint": "github:jquery/qunit",
   "raphael": "github:DmitryBaranovskiy/raphael",
   "ratchet": "github:maker/ratchet",
+  "raven-js": "github:getsentry/raven-js",
   "react": "npm:react",
   "react-router": "npm:react-router",
   "reqwest": "github:ded/reqwest",


### PR DESCRIPTION
Add [Sentry's](https://getsentry.com) [raven-js](https://github.com/getsentry/raven-js) client with main override to the registry.
