### PR TITLE
Add github:floatdrop/plugin-jsx as jsx

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -5,6 +5,7 @@
   "json": "github:systemjs/plugin-json",
   "md": "github:guybedford/system-md",
   "text": "github:systemjs/plugin-text",
+  "jsx": "github:floatdrop/plugin-jsx",
 
   "extra": "thing",
   "ace": "github:ajaxorg/ace-builds",


### PR DESCRIPTION
Hi! I'm using jspm with react jsx templates and want to use `require('template.jsx!');` syntax to load them.

Is there plans to add `jsx` plugin under official `systemjs`?
