### PR TITLE
angular-ui-tree moved to an organization

### DIFF
--- a/package-overrides/github/JimLiu/angular-ui-tree@2.1.5.json
+++ b/package-overrides/github/JimLiu/angular-ui-tree@2.1.5.json
@@ -1,6 +1,0 @@
-{
-  "main": "angular-ui-tree.min",
-  "directories": {
-    "lib": "dist"
-  }
-}

--- a/package-overrides/github/angular-ui-tree/angular-ui-tree@2.1.5.json
+++ b/package-overrides/github/angular-ui-tree/angular-ui-tree@2.1.5.json
@@ -1,0 +1,6 @@
+{
+  "main": "angular-ui-tree.min",
+  "directories": {
+    "lib": "dist"
+  }
+}

--- a/registry.json
+++ b/registry.json
@@ -22,7 +22,7 @@
   "angular-ui-router": "github:angular-ui/ui-router",
   "angular-ui-router-extras": "github:christopherthielen/ui-router-extras",
   "angular-ui-select": "github:angular-ui/ui-select",
-  "angular-ui-tree": "github:JimLiu/angular-ui-tree",
+  "angular-ui-tree": "github:angular-ui-tree/angular-ui-tree",
   "angular-sanitize": "github:angular/bower-angular-sanitize",
   "assert": "github:jspm/nodelibs-assert",
   "aurelia-binding": "github:aurelia/binding",


### PR DESCRIPTION
This package stopped working because it was moved to an organization. I thought jspm handled github redirects, but it was getting a 404 finding the js file for angular-ui-tree after `jspm install` was run on the project. Updated the registry to reflect the correct place and added a new package-override. 

Is there any reason to keep package-overrides/github/JimLiu, or should it be removed as well? I don't want to break things for anyone, but I'm not sure it does any good anymore.
