### PR TITLE
feat(nprogress): add updated package override

### DIFF
--- a/package-overrides/github/rstacruz/nprogress@0.1.6.json
+++ b/package-overrides/github/rstacruz/nprogress@0.1.6.json
@@ -1,0 +1,11 @@
+{
+  "format": "global", 
+  "shim": { 
+    "nprogress": { 
+      "deps": ["./nprogress.css!"] 
+    } 
+  }, 
+  "dependencies": { 
+    "css": "*" 
+  } 
+}


### PR DESCRIPTION
This updates the override config based on feedback from @guybedford in the gitter channel. I have tested this and it works correctly with `import * as nprogress from 'nprogress';` I'm also submitting a PR to the nprogress repo to add the override to their package.json file.