### PR TITLE
added happy -> github:henrikjoreteg/Happy.js

### DIFF
--- a/package-overrides/github/henrikjoreteg/Happy.js@v0.8.json
+++ b/package-overrides/github/henrikjoreteg/Happy.js@v0.8.json
@@ -1,6 +1,13 @@
 {
     "main": "./happy.js",
     "registry": "jspm",
+    "shim": {
+        "happy": {
+            "deps": [
+                "jquery"
+            ]
+        }
+    },
     "dependencies": {
         "jquery": "jquery@^2.1.1"
     }

--- a/package-overrides/github/henrikjoreteg/Happy.js@v0.8.json
+++ b/package-overrides/github/henrikjoreteg/Happy.js@v0.8.json
@@ -1,0 +1,4 @@
+{
+    "main": "./happy.js",
+    "registry": "jspm"
+}

--- a/package-overrides/github/henrikjoreteg/Happy.js@v0.8.json
+++ b/package-overrides/github/henrikjoreteg/Happy.js@v0.8.json
@@ -1,4 +1,7 @@
 {
     "main": "./happy.js",
-    "registry": "jspm"
+    "registry": "jspm",
+    "dependencies": {
+        "jquery": "jquery@^2.1.1"
+    }
 }

--- a/package-overrides/github/jzaefferer/jquery-validation@1.13.1.json
+++ b/package-overrides/github/jzaefferer/jquery-validation@1.13.1.json
@@ -1,0 +1,14 @@
+{
+    "main": "./dist/jquery.validate.js",
+    "registry": "jspm",
+    "shim": {
+        "jquery-validation": {
+            "deps": [
+                "jquery"
+            ]
+        }
+    },
+    "dependencies": {
+        "jquery": "jquery@^2.1.1"
+    }
+}

--- a/registry.json
+++ b/registry.json
@@ -109,6 +109,7 @@
   "jquery-pjax": "github:defunkt/jquery-pjax",
   "jquery.cookie": "github:carhartl/jquery-cookie",
   "jquery.hammer": "github:hammerjs/jquery.hammer.js",
+  "jquery-validation": "github:jzaefferer/jquery-validation",
   "jsfromhell": "github:jonasraoni/JSFromHell",
   "jsplumb": "github:sporritt/jsPlumb",
   "kickstrap": "github:ajkochanowicz/Kickstrap",

--- a/registry.json
+++ b/registry.json
@@ -94,6 +94,7 @@
   "hammer": "github:hammerjs/hammer.js",
   "handlebars": "github:components/handlebars.js",
   "handlebars.js": "github:components/handlebars.js",
+  "happy": "github:henrikjoreteg/Happy.js",
   "http": "github:jspm/nodelibs-http",
   "https": "github:jspm/nodelibs-https",
   "i18next-client": "npm:i18next-client",


### PR DESCRIPTION
added Happy.js

i have one question/comment though.

Happy.js can be used with either jQuery or Zepto
I have added this override without any dependencies so the user can choose to use it with either one.
But the user will have to remember to install either jQuery or Zepto manually.

i tested the override it works fine but is this the best way to handle this situation or should i be doing something else to handle the OR situation ?