### PR TITLE
Add override for react-bootstrap

### DIFF
--- a/package-overrides/npm/react-bootstrap@0.13.3
+++ b/package-overrides/npm/react-bootstrap@0.13.3
@@ -1,0 +1,5 @@
+{
+  "peerDependencies": {
+    "react": "0.12.2"
+  }
+}


### PR DESCRIPTION
Apparently jspm doesn't quite handle fuzzier dependency declarations