### PR TITLE
Update famo.us override.

### DIFF
--- a/package-overrides/github/Famous/famous@0.3.0.json
+++ b/package-overrides/github/Famous/famous@0.3.0.json
@@ -1,13 +1,14 @@
 {
-    "directories": {
-        "lib": "src"
-    },
-    "dependencies": {
-        "css": "^0.1.0"
-    },
-    "shim": {
-        "*/*": {
-            "deps": ["../core/famous.css!"]
-        }
+  "directories": {
+    "lib": "src"
+  },
+  "dependencies": {
+    "css": "^0.1.0",
+    "famous-polyfills": "github:Famous/polyfills"
+  },
+  "shim": {
+    "*": {
+      "deps": ["src/core/famous.css!", "famous-polyfills"]
     }
+  }
 }

--- a/package-overrides/github/Famous/famous@0.3.0.json
+++ b/package-overrides/github/Famous/famous@0.3.0.json
@@ -7,7 +7,37 @@
     "famous-polyfills": "github:Famous/polyfills"
   },
   "shim": {
-    "*": {
+    "core/*": {
+      "deps": ["src/core/famous.css!", "famous-polyfills"]
+    },
+    "events/*": {
+      "deps": ["src/core/famous.css!", "famous-polyfills"]
+    },
+    "inputs/*": {
+      "deps": ["src/core/famous.css!", "famous-polyfills"]
+    },
+    "math/*": {
+      "deps": ["src/core/famous.css!", "famous-polyfills"]
+    },
+    "modifiers/*": {
+      "deps": ["src/core/famous.css!", "famous-polyfills"]
+    },
+    "physics/*": {
+      "deps": ["src/core/famous.css!", "famous-polyfills"]
+    },
+    "surfaces/*": {
+      "deps": ["src/core/famous.css!", "famous-polyfills"]
+    },
+    "transitions/*": {
+      "deps": ["src/core/famous.css!", "famous-polyfills"]
+    },
+    "utilities/*": {
+      "deps": ["src/core/famous.css!", "famous-polyfills"]
+    },
+    "views/*": {
+      "deps": ["src/core/famous.css!", "famous-polyfills"]
+    },
+    "widgets/*": {
       "deps": ["src/core/famous.css!", "famous-polyfills"]
     }
   }


### PR DESCRIPTION
This is theoretically what should work (i think?), but the shim doesn't add

```
"deps src/core/famous.css!";
"deps famous-polyfills";
```

to any files. Why is that again?