### PR TITLE
Added overrides and endpoint for three.js

### DIFF
--- a/package-overrides/github/mrdoob/three.js@r70.json
+++ b/package-overrides/github/mrdoob/three.js@r70.json
@@ -1,0 +1,10 @@
+{ 
+	"main": "build/three",
+ 	"ignore": ["docs", "src", "editor", "test", "utils", "examples/*.html", "examples/models", "examples/scenes", "examples/sounds", "examples/obj", "examples/textures"],
+ 	"format": "global", 
+ 	"shim": { 
+ 		"build/three": {
+ 			"exports": "THREE"
+ 		}
+ 	}
+ }

--- a/registry.json
+++ b/registry.json
@@ -178,6 +178,7 @@
   "stream": "github:jspm/nodelibs-stream",
   "string_decoder": "github:jspm/nodelibs-string_decoder",
   "tabletools": "github:DataTables/TableTools",
+  "three.js": "github:mrdoob/three.js@r70",
   "theseus": "npm:theseus",
   "theseus-angular": "npm:theseus-angular",
   "timers": "github:jspm/nodelibs-timers",


### PR DESCRIPTION
Example of how to use:

import THREE from 'three.js';
import 'three.js/examples/js/renderers/Projector';