### PR TITLE
Update Zurb Foundation to 5.5.1

### DIFF
--- a/package-overrides/github/zurb/bower-foundation@5.0.2.json
+++ b/package-overrides/github/zurb/bower-foundation@5.0.2.json
@@ -2,14 +2,12 @@
   "main": "js/foundation/foundation",
   "shim": {
     "js/foundation/foundation.*": "./foundation",
-    "js/foundation/foundation": ["jquery", "../vendor/custom.modernizr"]
+    "js/foundation/foundation": ["jquery", "../vendor/modernizr"]
   },
   "ignore": [
     "js/foundation.min.js", 
-    "scss", 
     "js/vendor/jquery.cookie.js", 
     "js/vendor/jquery.js",
-    "js/vendor/fastclick.js",
     "js/vendor/jquery.autocomplete.js",
     "js/vendor/placeholder.js"
   ],

--- a/package-overrides/github/zurb/bower-foundation@5.0.2.json
+++ b/package-overrides/github/zurb/bower-foundation@5.0.2.json
@@ -2,12 +2,13 @@
   "main": "js/foundation/foundation",
   "shim": {
     "js/foundation/foundation.*": "./foundation",
-    "js/foundation/foundation": ["../vendor/jquery"]
+    "js/foundation/foundation": ["jquery", "../vendor/custom.modernizr"]
   },
   "ignore": [
     "js/foundation.min.js", 
+    "scss",
     "js/vendor/jquery.cookie.js", 
-    "js/vendor/modernizr.js",
+    "js/vendor/jquery.js",
     "js/vendor/fastclick.js",
     "js/vendor/jquery.autocomplete.js",
     "js/vendor/placeholder.js"

--- a/package-overrides/github/zurb/bower-foundation@5.5.1.json
+++ b/package-overrides/github/zurb/bower-foundation@5.5.1.json
@@ -2,12 +2,13 @@
   "main": "js/foundation/foundation",
   "shim": {
     "js/foundation/foundation.*": "./foundation",
-    "js/foundation/foundation": ["jquery", "../vendor/modernizr"]
+    "js/foundation/foundation": ["../vendor/jquery"]
   },
   "ignore": [
     "js/foundation.min.js", 
     "js/vendor/jquery.cookie.js", 
-    "js/vendor/jquery.js",
+    "js/vendor/modernizer.js",
+    "js/vendor/fastclick.js",
     "js/vendor/jquery.autocomplete.js",
     "js/vendor/placeholder.js"
   ],


### PR DESCRIPTION
SCSS files are needed in some Foundation workflows and should not be excluded.