### PR TITLE
Added pdfmake@0.1.15

### DIFF
--- a/package-overrides/github/bpampuch/pdfmake@0.1.15.json
+++ b/package-overrides/github/bpampuch/pdfmake@0.1.15.json
@@ -1,0 +1,6 @@
+{
+  "main": "pdfmake",
+  "directories": {
+    "lib": "build"
+  }
+}

--- a/registry.json
+++ b/registry.json
@@ -169,6 +169,7 @@
   "page": "npm:page",
   "parallax": "github:wagerfield/parallax",
   "path": "github:jspm/nodelibs-path",
+  "pdfmake": "github:bpampuch/pdfmake",
   "phaser": "github:photonstorm/phaser",
   "pikaday": "github:dbushell/Pikaday",
   "poly": "github:cujojs/poly",


### PR DESCRIPTION
Doesn't link `vfs_fonts.js` as, according to [this](https://github.com/bpampuch/pdfmake#getting-started) it's user's choice which font should be used. [Here](https://github.com/bpampuch/pdfmake/issues/33#issuecomment-45792827) is a guide how to apply custom font.