### PR TITLE
Added entry for angular-ui/ui-router for version 0.2.13.

### DIFF
--- a/package-overrides/github/angular-ui/ui-router@0.2.13.json
+++ b/package-overrides/github/angular-ui/ui-router@0.2.13.json
@@ -1,0 +1,11 @@
+{
+  "shim": {
+    "angular-ui-router": {
+      "deps": ["angular"]
+    }
+  },
+  "registry": "jspm",
+  "dependencies": {
+    "angular": "^1.3.2"
+  }
+}


### PR DESCRIPTION
Currently, when executing the command `jspm install angular-ui-router`, the main file fails to be added properly. The addition of this registry entry fixes the problem. Here is the error message that appears in installation:

```
Updating registry cache...
Looking up github:angular-ui/ui-router
Downloading github:angular-ui/ui-router@0.2.13
Looking up github:angular/bower-angular

warn No main entry point detected for github:angular-ui/ui-router@0.2.13.
     Try adding an override, or set the package.json "main": false if this is the intention.

ok   Installed angular-ui-router as github:angular-ui/ui-router@^0.2.13 (0.2.13)
     Installed Forks

                           github:angular/bower-angular 1.2.28 1.3.13

     To inspect individual package constraints, use jspm inspect endpoint:name.

ok   Install complete.
```