### PR TITLE
Added plugin-ember-hbs

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -10,6 +10,7 @@
   "jsx": "github:floatdrop/plugin-jsx",
   "less": "github:aaike/jspm-less-plugin",
   "ts": "github:frankwallis/plugin-typescript",
+  "ember-hbs": "github:n-fuse/plugin-ember-hbs",
 
   "ace": "github:ajaxorg/ace-builds",
   "angular": "github:angular/bower-angular",

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,7 @@
 {
   "coffee": "github:forresto/plugin-coffee",
   "css": "github:systemjs/plugin-css",
+  "ember-hbs": "github:n-fuse/plugin-ember-hbs",
   "font": "github:guybedford/system-font",
   "image": "github:systemjs/plugin-image",
   "json": "github:systemjs/plugin-json",
@@ -10,7 +11,6 @@
   "jsx": "github:floatdrop/plugin-jsx",
   "less": "github:aaike/jspm-less-plugin",
   "ts": "github:frankwallis/plugin-typescript",
-  "ember-hbs": "github:n-fuse/plugin-ember-hbs",
 
   "ace": "github:ajaxorg/ace-builds",
   "angular": "github:angular/bower-angular",


### PR DESCRIPTION
Is it ok if the name does not match the file extension? Ember hbs is not compatible with Handlebars but uses the same file extension (hbs).