### PR TITLE
Added an override for the most recent Ember.js Beta #5 (debug)

### DIFF
--- a/package-overrides/github/components/ember@1.11.0-beta.5
+++ b/package-overrides/github/components/ember@1.11.0-beta.5
@@ -1,0 +1,14 @@
+{
+  "main": "ember.debug",
+  "files": ["ember.debug.js"],
+  "dependencies": {
+    "jquery": "*"
+  },
+  "shim": {
+    "ember.debug": {
+      "deps": ["jquery"],
+      "exports": "Ember"
+    }
+  }
+}
+


### PR DESCRIPTION
I try to use the most recent version of Ember and it does not work w/o an override. There is a pull request to make the ember repo compatible with jspm (https://github.com/components/ember/pull/66) but it's not merged yet. In the mean time, I think it would be handy to have an override in the registry. 

A question in addition to the pull request: how do I switch between different versions of the lib? e.g. for development I would like to use ember.debug.js and for production ember.prod.js is better. And maybe the override should not include the debug version.. what do you think?

 