### PR TITLE
add alias for angular-xeditable, fix override

### DIFF
--- a/package-overrides/github/vitalets/angular-xeditable@0.1.8.json
+++ b/package-overrides/github/vitalets/angular-xeditable@0.1.8.json
@@ -1,3 +1,14 @@
 {
-  "main": "dist/js/xeditable.min"
+  "main": "dist/js/xeditable",
+  "shim": {
+    "dist/js/xeditable": {
+      "deps": [
+          "angular"
+        ]
+    }
+  },
+  "registry": "jspm",
+  "dependencies": {
+    "angular": "^1.3.0"
+  }
 }

--- a/registry.json
+++ b/registry.json
@@ -44,6 +44,7 @@
   "angular-ui-tree": "github:angular-ui-tree/angular-ui-tree",
   "angular-ui-utils": "github:angular-ui/ui-utils",
   "angular-youtube-embed": "github:brandly/angular-youtube-embed",
+  "angular-xeditable": "github:vitalets/angular-xeditable",
   "any-http-angular": "npm:any-http-angular",
   "any-http-jquery": "npm:any-http-jquery",
   "any-http-reqwest": "npm:any-http-reqwest",


### PR DESCRIPTION
I know the changed override might break stuff. But the angular dep is missing and what's more important, it uses the minified version by default.

Would this still be ok though?