### PR TITLE
Registry tests jspm/registry#259 + fix golden-layout@1.0.6.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+- '0.10'
+branches:
+  only:
+  - master
+notifications:
+  email:
+    recipients:
+    - i@2fd.me

--- a/package-overrides/npm/golden-layout@1.0.6.json
+++ b/package-overrides/npm/golden-layout@1.0.6.json
@@ -5,12 +5,12 @@
   "main": "dist/goldenlayout",
   "files": [
     "dist/goldenlayout.js",
-    "dist/goldenlayout.min.js",
+    "dist/goldenlayout.min.js"
   ],
   "format": "global",
   "registry": "jspm",
   "dependencies": {
-    "jquery": "*",
+    "jquery": "*"
   },
   "shim": {
     "dist/goldenlayout": ["jquery"]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "registry",
+  "version": "0.0.0",
+  "description": "The jspm registry and package.json override service",
+  "scripts": {
+    "test": "node test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jspm/registry.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jspm/registry/issues"
+  },
+  "homepage": "https://github.com/jspm/registry",
+  "private": true,
+  "dependencies": {
+    "colors": "^1.0.3",
+    "commander": "^2.7.1",
+    "glob": "^5.0.3",
+    "jspm-github": "git://github.com/jspm/github",
+    "jspm-npm": "git://github.com/jspm/npm",
+    "mout": "^0.11.0",
+    "q": "^1.2.0"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,78 @@
+"use strict";
+
+var log = require('./lib/log');
+var RegistryFile = require('./lib/RegistryFile');
+var OverrideFile = require('./lib/OverrideFile');
+var summary = [];
+
+/**
+ * Commander
+ */
+var program = require('commander');
+program
+  .version('0.0.1')
+  .usage('[options] <package ...>')
+  .option('-e, --only-errors', 'Show only summary', 0)
+  .parse(process.argv);
+
+
+/**
+ * registry.json
+ */
+var registry = RegistryFile();
+if(registry.errors().length)
+{
+	summary = summary.concat(registry.errors());
+	log.error(registry.errors());
+	process.exit(1);
+}
+
+// log ok
+if(!program.onlyErrors)
+	log.ok('registry.json');
+
+
+/**
+ * Packages
+ */
+registry.forEach(function(endpoint, name){
+
+	if(program.args.length && program.args.indexOf(name) === -1)
+		return;
+
+	var override = new OverrideFile(endpoint);
+
+	if(override.errors().length) {
+
+		var errorDescription = name + ' => ' + endpoint + '\n\t' + override.errors().join('\n\t');
+		summary.push(errorDescription);
+
+	} else if(!program.onlyErrors) {
+		log.ok(name + ' => ' + endpoint);
+
+		if(!override.isFile())
+			log.info(' not override file from ' + name);
+	}
+
+});
+
+
+/**
+ * Summary
+ */
+if(summary.length) {
+	log.n()
+		('Error summary ................')
+		.error(summary)
+		.n();
+
+	process.exit(1);
+
+}
+
+log.n()
+	('Summary ................')
+	.ok('excellent!! all is well.')
+	.n();
+
+process.exit(0);

--- a/test/lib/JsonFile.js
+++ b/test/lib/JsonFile.js
@@ -1,0 +1,56 @@
+"use strict;"
+var fs = require('fs');
+var mout = require('mout');	
+var extend = mout.object.deepMixIn;
+var forOwn = mout.object.forOwn;
+
+/**
+ * @constructor JsonFile
+ */		
+
+var JsonFile = module.exports = function JsonFile(file){
+
+	if( !(this instanceof JsonFile) )
+		return new JsonFile(file);
+
+	this._file = String(file);
+	this._errors = this._errors || [];
+	this._json = this._json || {};
+
+	if( !(/\.json$/.test(file)) ){
+		this.error(this._file + ' is not json file');
+	
+	} else {
+
+		try{
+			extend(this._json, require(this._file));
+
+		} catch(e) {
+
+			this.error(e.message);
+		}
+
+	}
+};
+
+JsonFile.prototype.error = function(msg){
+
+	this._errors.push(msg);
+
+	return this;
+}
+
+JsonFile.prototype.errors = function(){
+
+	return this._errors;
+}
+
+JsonFile.prototype.forEach = function(fn){
+
+	forOwn(this._json, fn, this);
+
+	return this;	
+};
+
+
+

--- a/test/lib/OverrideFile.js
+++ b/test/lib/OverrideFile.js
@@ -1,0 +1,88 @@
+"use strict;"
+
+var fs = require('fs');
+var util = require('util');
+var path = require('path');
+var glob = require('glob');
+var mout = require('mout');
+var colors = require('colors/safe');
+var JsonFile = require('./JsonFile');
+
+var registries = {
+	github: require('jspm-github'),
+	npm: require('jspm-npm')
+};
+
+/**
+ * @constructor OverrideFile
+ */		
+var OverrideFile = module.exports = function OverrideFile(endpoint){
+
+	if( !(this instanceof OverrideFile) )
+		return new OverrideFile(endpoint);
+
+	this._endpoint = endpoint;
+	this._files = [];
+	this._errors = this._errors || [];
+	this._registry;
+	this._package;
+
+	var match = /^([^:\s]*):([^\s]*)$/.exec(endpoint);
+
+	if(!match)
+	{
+		this.error('invalid enpoint package');
+	}
+	else
+	{
+		this._registry = match[1];
+		this._package = match[2];
+
+		if(!registries[this._registry])
+		{
+			this.error('invalid registry');
+		}
+		else if(!registries[this._registry].packageFormat.test(this._package))
+		{
+			this.error('invalid pacakge name');
+		}
+
+		this._glob = path.resolve('./package-overrides', this._registry) + '/' + this._package + '@*.json';
+
+
+		this._files = glob.sync(this._glob);
+		this.forEach(function(file){
+
+			var err = JsonFile(file).errors();
+
+			if(err.length > 0)
+				this.error(JsonFile(file).errors().join('\n'));
+
+		});
+	}
+
+};
+
+util.inherits(OverrideFile, JsonFile);
+
+OverrideFile.prototype.error = function(msg){
+
+	var result = '';
+	result += this._endpoint ? colors.gray(this._endpoint) + ' ' : '';
+	result += msg;
+
+	return JsonFile.prototype.error.call(this, result);
+};
+
+OverrideFile.prototype.forEach = function(fn){
+
+	mout.array.forEach(this._files, fn, this);
+
+	return this;	
+};
+
+OverrideFile.prototype.isFile = function(){
+
+	return this._files.length > 0;
+};
+

--- a/test/lib/RegistryFile.js
+++ b/test/lib/RegistryFile.js
@@ -1,0 +1,19 @@
+"use strict;"
+var util = require('util');
+var path = require('path');
+var JsonFile = require('./JsonFile');
+
+/**
+ * @constructor RegistryFile
+ */		
+
+var RegistryFile = module.exports = function RegistryFile(){
+
+	if( !(this instanceof RegistryFile) )
+		return new RegistryFile();
+
+	JsonFile.call(this, path.resolve('./registry.json'));
+};
+
+
+util.inherits(RegistryFile, JsonFile);

--- a/test/lib/log.js
+++ b/test/lib/log.js
@@ -1,0 +1,55 @@
+"use strict";
+
+var util = require('util');
+var mout = require('mout');
+var colors = require('colors/safe');
+
+var log = function(msg, color){
+
+	if(colors[color])
+		msg = colors[color](msg);
+
+	console.log( msg );
+	return log;
+};
+
+log.ok = function(msg){
+
+	if(Array.isArray(msg))
+	{
+		msg.forEach(log.ok);
+		return log;
+	}
+
+	return log( util.format( '✓ %s', msg), 'green');
+};
+
+log.error = function(msg){
+
+	if(Array.isArray(msg))
+	{
+		msg.forEach(log.error);
+		return log;
+	}
+
+	return log(util.format( '✗ %s', msg), 'red');
+};
+
+log.info = function(msg){
+
+	if(Array.isArray(msg))
+	{
+		msg.forEach(log.info);
+		return log;
+	}
+
+	return log(util.format( '  %s', msg), 'cyan');
+};
+
+log.n = function(count){
+
+	count = mout.lang.isNumber(count) && count > 0 ? mout.number.toInt(count) : 0;
+	return log(mout.string.repeat("\n", count));
+}
+
+module.exports = log;


### PR DESCRIPTION
command tool from file validation: `node test`

`node test --help`
![image](https://cloud.githubusercontent.com/assets/208789/6726772/f9fed506-cdf9-11e4-801d-8a113df97f17.png)

`node test -e` display only errors if they occurred
![image](https://cloud.githubusercontent.com/assets/208789/6726780/15151576-cdfa-11e4-847e-0a8682d06b23.png)

![image](https://cloud.githubusercontent.com/assets/208789/6726721/60dfd758-cdf9-11e4-9a40-f64a05b03373.png)

`node test <package ...>` validate only `registry.json` and overrides from specific package
`node test ace angular react`
![image](https://cloud.githubusercontent.com/assets/208789/6726855/f423cf6e-cdfa-11e4-803f-e237fa6d424f.png)

by default validates all
Example fail: https://travis-ci.org/2fd/registry/builds/54988938
Example passing: https://travis-ci.org/2fd/registry/builds/54989331
