### PR TITLE
Fixed export for foundation

### DIFF
--- a/package-overrides/github/zurb/bower-foundation@5.5.1.json
+++ b/package-overrides/github/zurb/bower-foundation@5.5.1.json
@@ -1,8 +1,12 @@
 {
   "main": "js/foundation/foundation",
+  "format": "global",
   "shim": {
     "js/foundation/foundation.*": "./foundation",
-    "js/foundation/foundation": ["../vendor/jquery"]
+    "js/foundation/foundation": {
+      "deps": "jquery",
+      "exports": "Foundation"
+    }
   },
   "ignore": [
     "js/foundation.min.js", 


### PR DESCRIPTION
`import Foundation from 'foundation';` now sets the proper foundation export 