### PR TITLE
Creates font-awesome@4.3.0 override.

### DIFF
--- a/package-overrides/npm/font-awesome@4.3.0.json
+++ b/package-overrides/npm/font-awesome@4.3.0.json
@@ -1,0 +1,4 @@
+{
+  "main": "css/font-awesome.css!",
+  "jspmNodeConversion": false
+}


### PR DESCRIPTION
This allows importing of the font-awesome CSS file without including the version/path like `import 'font-awesome'`.  Fixes https://github.com/systemjs/plugin-css/issues/26