### PR TITLE
Add angular-formly@5.0.3 Override

### DIFF
--- a/package-overrides/github/formly-js/angular-formly@5.0.3.json
+++ b/package-overrides/github/formly-js/angular-formly@5.0.3.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "api-check": "github:kentcdodds/apiCheck.js@^6.0.11"
+  }
+}

--- a/registry.json
+++ b/registry.json
@@ -22,6 +22,7 @@
   "angular-breadcrumb": "github:ncuillery/angular-breadcrumb",
   "angular-cookies": "github:angular/bower-angular-cookies",
   "angular-file-upload": "github:danialfarid/angular-file-upload-bower",
+  "angular-formly": "github:formly-js/angular-formly",
   "angular-google-maps": "github:angular-ui/angular-google-maps",
   "angular-http-auth": "github:witoldsz/angular-http-auth",
   "angular-loading-bar": "github:chieffancypants/angular-loading-bar",


### PR DESCRIPTION
This PR adds angular-formly override so it can find its dependencies while going through `jspm` workflow.