### PR TITLE
Package override for engine.io-client, xmlhttprequest dependency 

### DIFF
--- a/package-overrides/npm/engine.io-client@1.5.1.json
+++ b/package-overrides/npm/engine.io-client@1.5.1.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-      "xmlhttprequest" : "git+https://github.com/rase-/node-XMLHttpRequest.git#add/ssl-support"
+      "xmlhttprequest" : "git+https://github.com/rase-/node-XMLHttpRequest.git#add/ssl-support",
       "has-cors": "1.0.3",
       "ws": "0.7.1",
       "component-emitter": "1.1.2",

--- a/package-overrides/npm/engine.io-client@1.5.1.json
+++ b/package-overrides/npm/engine.io-client@1.5.1.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-      "xmlhttprequest" : "git+https://github.com/rase-/node-XMLHttpRequest@add/ssl-support"
+      "xmlhttprequest" : "git+https://github.com/rase-/node-XMLHttpRequest.git#add/ssl-support"
   }
 }

--- a/package-overrides/npm/engine.io-client@1.5.1.json
+++ b/package-overrides/npm/engine.io-client@1.5.1.json
@@ -1,5 +1,15 @@
 {
   "dependencies": {
       "xmlhttprequest" : "git+https://github.com/rase-/node-XMLHttpRequest.git#add/ssl-support"
+      "has-cors": "1.0.3",
+      "ws": "0.7.1",
+      "component-emitter": "1.1.2",
+      "indexof": "0.0.1",
+      "engine.io-parser": "1.2.1",
+      "debug": "2.1.3",
+      "parseuri": "0.0.4",
+      "parsejson": "0.0.1",
+      "parseqs": "0.0.2",
+      "component-inherit": "0.0.3"
   }
 }

--- a/package-overrides/npm/engine.io-client@1.5.1.json
+++ b/package-overrides/npm/engine.io-client@1.5.1.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+      "xmlhttprequest" : "https://github.com/rase-/node-XMLHttpRequest@add/ssl-support"
+  }
+}

--- a/package-overrides/npm/engine.io-client@1.5.1.json
+++ b/package-overrides/npm/engine.io-client@1.5.1.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-      "xmlhttprequest" : "https://github.com/rase-/node-XMLHttpRequest@add/ssl-support"
+      "xmlhttprequest" : "git+https://github.com/rase-/node-XMLHttpRequest@add/ssl-support"
   }
 }


### PR DESCRIPTION
This is to address: https://github.com/jspm/jspm-cli/issues/627
The referenced commit is the top commit in a branch called "add/ssl-support".
However, this fix depends on https://github.com/jspm/jspm-cli/pull/679
