### PR TITLE
Add Semantic-UI

### DIFF
--- a/package-overrides/github/Semantic-Org/Semantic-UI@1.11.8.json
+++ b/package-overrides/github/Semantic-Org/Semantic-UI@1.11.8.json
@@ -1,0 +1,19 @@
+{
+  "directories": {
+    "lib": "dist"
+  },
+  "main": "semantic",
+  "shim": {
+    "semantic": {
+      "deps": [
+        "jquery",
+        "./semantic.css!"
+      ],
+      "exports": "$"
+    }
+  },
+  "dependencies": {
+    "jquery": "github:components/jquery",
+    "css": "github:systemjs/plugin-css"
+  }
+}

--- a/registry.json
+++ b/registry.json
@@ -251,6 +251,7 @@
   "saairey-bootstrap-wizard": "github:saairey/bootstrap-wizard",
   "select2": "github:select2/select2",
   "selectize": "github:brianreavis/selectize.js",
+  "semantic-ui": "Semantic-Org/Semantic-UI",
   "scoped-polyfill": "github:PM5544/scoped-polyfill",
   "showdown": "github:showdownjs/showdown",
   "sifter": "github:brianreavis/sifter.js",


### PR DESCRIPTION
As in https://github.com/jspm/registry/issues/306#issuecomment-93691910, I've tested this and it is working fine for me.

@glen-84 the exports are useful so that the import value of semanticUI is jquery itself - `import $ from 'semantic-ui'` which saves some typing. Also I had to make the CSS file loaded relatively.

Feedback welcome before merge.