### PR TITLE
Add override for kasperlewau/angular-bind-notifier

### DIFF
--- a/package-overrides/github/kasperlewau/angular-bind-notifier@0.0.4.json
+++ b/package-overrides/github/kasperlewau/angular-bind-notifier@0.0.4.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "angular": "^1.3.0"
+  },
+  "shim": {
+    "angular-bind-notifier": {
+      "deps": "angular"
+    }
+  }
+}

--- a/registry.json
+++ b/registry.json
@@ -18,6 +18,7 @@
   "angular-agility": "github:AngularAgility/AngularAgility",
   "angular-animate": "github:angular/bower-angular-animate",
   "angular-aria": "github:angular/bower-angular-aria",
+  "angular-bind-notifier": "github:kasperlewau/angular-bind-notifier",
   "angular-bootstrap": "github:angular-ui/bootstrap-bower",
   "angular-breadcrumb": "github:ncuillery/angular-breadcrumb",
   "angular-cookies": "github:angular/bower-angular-cookies",


### PR DESCRIPTION
Added dependency shim and endpoint mapping. 

Installed/imported the package with the following (for testing purposes): 
```js 
jspm install angular-bind-notifier=github:kasperlewau/angular-bind-notifier
import 'angular-bind-notifier';
```

I've read through the [package testing](https://github.com/jspm/registry/wiki/Configuring-Packages-for-jspm#testing-configuration) and the [package dependencies](https://github.com/jspm/registry/wiki/Configuring-Packages-for-jspm#package-dependencies) sections but I cannot make much sense out of it, specifically in terms of package dependencies. 

I've tested manual overrides (`-o`) with the given dependency list (in this case, angular) and they appear to not yield a different result, so I'm not 100% that the changes made in `package-overrides/github/kasperlewau/angular-bind-notifier@0.0.4.json` are in fact needed. 

Please do let me know if I'm at fault here and/or if there is a scenario where my notion that it doesn't matter can be debunked. 