### PR TITLE
Correct the shim path for angular-bind-notifier.

### DIFF
--- a/package-overrides/github/kasperlewau/angular-bind-notifier@0.0.4.json
+++ b/package-overrides/github/kasperlewau/angular-bind-notifier@0.0.4.json
@@ -3,7 +3,7 @@
     "angular": "^1.3.0"
   },
   "shim": {
-    "angular-bind-notifier": {
+    "dist/angular-bind-notifier": {
       "deps": "angular"
     }
   }


### PR DESCRIPTION
Now points to dist/angular-bind-notifier as intended, correction of  a mistake introduced in #341. *sorry*.

poke @guybedford