### PR TITLE
fix oidc-client

### DIFF
--- a/package-overrides/github/IdentityModel/oidc-client@0.2.1.json
+++ b/package-overrides/github/IdentityModel/oidc-client@0.2.1.json
@@ -1,5 +1,6 @@
 {
   "main":"oidc-client.js",
+  "format": "global",
   "directories": {
     "lib": "dist"
   }


### PR DESCRIPTION
was missing the `"format": "global"`