### PR TITLE
added socket.io-client

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -261,6 +261,7 @@
   "sifter": "github:brianreavis/sifter.js",
   "skrollr": "github:Prinzhorn/skrollr",
   "sockjs-client": "github:sockjs/sockjs-client",
+  "socket.io-client": "npm:socket.io-client",
   "socket.io-rpc-client": "github:capaj/socket.io-rpc-client",
   "spin": "github:fgnass/spin.js",
   "stomp-websocket": "github:jmesnil/stomp-websocket",


### PR DESCRIPTION
socket.io-client succesfull install depends on a release which fixes https://github.com/jspm/jspm-cli/issues/685, but I think we could merge it now, let people who already installed latest master with `npm i git+https://github.com/jspm/jspm-cli.git -g` enjoy easier workflow for isomorphic apps.