### PR TITLE
Create nsPopover@0.6.7.json

### DIFF
--- a/package-overrides/github/nohros/nsPopover@0.6.7.json
+++ b/package-overrides/github/nohros/nsPopover@0.6.7.json
@@ -11,8 +11,6 @@
   },
   "format": "global",
   "shim": {
-    "src/nsPopover": {
-      "deps": ["angular"]
-    }
+    "src/nsPopover": ["angular"]
   }
 }

--- a/package-overrides/github/nohros/nsPopover@0.6.7.json
+++ b/package-overrides/github/nohros/nsPopover@0.6.7.json
@@ -1,10 +1,5 @@
 {
   "main": "src/nsPopover",
-  "files": [
-    "src/nsPopover.js",
-    "less/ns-popover.less",
-    "sass/ns-popover.scss"
-  ],
   "registry": "jspm",
   "dependencies": {
       "angular": "^1.2.9"

--- a/package-overrides/github/nohros/nsPopover@0.6.7.json
+++ b/package-overrides/github/nohros/nsPopover@0.6.7.json
@@ -1,0 +1,18 @@
+{
+  "main": "src/nsPopover",
+  "files": [
+    "src/nsPopover.js",
+    "less/ns-popover.less",
+    "sass/ns-popover.scss",
+  ],
+  "registry": "jspm",
+  "dependencies": {
+      "angular": "^1.2.9"
+  },
+  "format": "global",
+  "shim": {
+    "src/nsPopover": {
+      "deps": ["angular"]
+    }
+  }
+}

--- a/package-overrides/github/nohros/nsPopover@0.6.7.json
+++ b/package-overrides/github/nohros/nsPopover@0.6.7.json
@@ -3,7 +3,7 @@
   "files": [
     "src/nsPopover.js",
     "less/ns-popover.less",
-    "sass/ns-popover.scss",
+    "sass/ns-popover.scss"
   ],
   "registry": "jspm",
   "dependencies": {


### PR DESCRIPTION
Add jspm registry support for nsPopover: https://github.com/nohros/nsPopover

Can't seem to get less/ns-popover.less file included although it's listed in "files". Is there a filter on .less files?