### PR TITLE
Updated registry for golden-layout to point to version 1.0.8 and github

### DIFF
--- a/package-overrides/github/hoxton-one/golden-layout@1.0.8.json
+++ b/package-overrides/github/hoxton-one/golden-layout@1.0.8.json
@@ -1,0 +1,11 @@
+{
+  "main": "dist/goldenlayout",
+  "format": "global",
+  "registry": "jspm",
+  "dependencies": {
+    "jquery": "*"
+  },
+  "shim": {
+    "dist/goldenlayout": ["jquery"]
+  }
+}

--- a/registry.json
+++ b/registry.json
@@ -149,7 +149,7 @@
   "font-awesome": "npm:font-awesome",
   "foundation": "github:zurb/bower-foundation",
   "fs": "github:jspm/nodelibs-fs",
-  "golden-layout": "npm:golden-layout",
+  "golden-layout": “github:hoxton-one/golden-layout",
   "hammer": "github:hammerjs/hammer.js",
   "handlebars": "github:components/handlebars.js",
   "handlebars.js": "github:components/handlebars.js",


### PR DESCRIPTION
Left old npm/golden-layout@1.0.6.json file in npm overrides.  Needed version 1.0.8 of golden layout via jspm.  In addition, the npm/golden-layout@1.0.6.json file was using the frowned upon `files` entry, and not including things like the css source files, etc.