### PR TITLE
Add kl-watch-once shortlist mapping

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -188,6 +188,7 @@
   "jsplumb": "github:sporritt/jsPlumb",
   "kickstrap": "github:ajkochanowicz/Kickstrap",
   "klayjs": "github:OpenKieler/klayjs",
+  "kl-watch-once": "github:kasperlewau/kl-watch-once",
   "kendoui": "github:kendo-labs/bower-kendo-ui",
   "knockout": "github:knockout/knockout",
   "knockout-validation": "github:Knockout-Contrib/Knockout-Validation",


### PR DESCRIPTION
shortlist mapping for [kl-watch-once](https://github.com/kasperlewau/kl-watch-once). 

tested locally, no overrides appear to be necessary to get this running - `import 'kl-watch-once'` works just dandy. 