### PR TITLE
Adding Dimple (D3-based charting library)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -130,6 +130,7 @@
   "decimal.js": "github:MikeMcl/decimal.js",
   "dgram": "github:jspm/nodelibs-dgram",
   "di": "github:angular/di.js",
+  "dimple": "github:PMSI-AlignAlytics/dimple/dist/dimple.latest"
   "dns": "github:jspm/nodelibs-dns",
   "domain": "github:jspm/nodelibs-domain",
   "dropzone": "github:enyo/dropzone",


### PR DESCRIPTION
Dimple is hosted on Github, but doesn't have a `dimple.js` or `index.js` in the project. But we can directly reference the latest version without too much trouble (or should we use `dimple.latest.min` instead?)