### PR TITLE
Adding fetch to registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -147,6 +147,7 @@
   "famous-angular": "github:Famous/famous-angular",
   "famous-polyfills": "github:Famous/polyfills",
   "fastclick": "npm:fastclick",
+  "fetch": "github:github/fetch",
   "firebase": "github:firebase/firebase-bower",
   "flowtype": "github:simplefocus/FlowType.JS",
   "font-awesome": "npm:font-awesome",


### PR DESCRIPTION
The `github/fetch` polyfill is getting a bit more use at the moment. The only problem is you have to `import 'github:github/fetch'` instead of `import fetch from 'github:github/fetch'`, since it edits global scope. I still think it should be added, though, but happy to hear objections.