### PR TITLE
Add angular-subscribe to the registry shortlist

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -40,6 +40,7 @@
   "angular-sanitize": "github:angular/bower-angular-sanitize",
   "angular-smart-table": "github:lorenzofox3/Smart-Table",
   "angular-strap": "github:mgcrea/angular-strap",
+  "angular-subscribe": "github:kasperlewau/angular-subscribe",
   "angular-touch": "github:angular/bower-angular-touch",
   "angular-translate": "github:angular-translate/bower-angular-translate",
   "angular-translate-loader-static-files": "github:angular-translate/bower-angular-translate-loader-static-files",


### PR DESCRIPTION
shortlist mapping for [angular-subscribe](https://github.com/kasperlewau/angular-subscribe).

tested locally, no overrides appear to be necessary to get this running - import 'angular-subscribe' works just dandy.