### PR TITLE
Angular material 0.9.0 overrides added

### DIFF
--- a/package-overrides/github/angular/bower-material@0.9.0.json
+++ b/package-overrides/github/angular/bower-material@0.9.0.json
@@ -1,0 +1,12 @@
+{
+	"main": "index",
+	"registry": "jspm",
+  	"dependencies": {
+  		"css": "github:systemjs/plugin-css@^0.1.9"
+  	},
+	"shim": {
+    "angular-material": {
+      "deps": [ "./angular-material.css!" ]
+    }
+  }
+}


### PR DESCRIPTION
This purposely does not define angular dependencies to allow the users to specify project angular dependencies versions (e.g 1.3.15 or 1.4.0 ) - This follows the Angular teams last override which removed all angular dependencies.

This commit however does add the css shim for a better usage pattern inside JSPM