### PR TITLE
Update angular-formly overrides and add api-check dependency

### DIFF
--- a/package-overrides/github/formly-js/angular-formly@5.0.3.json
+++ b/package-overrides/github/formly-js/angular-formly@5.0.3.json
@@ -1,5 +1,0 @@
-{
-  "dependencies": {
-    "api-check": "github:kentcdodds/apiCheck.js@^6.0.11"
-  }
-}

--- a/package-overrides/npm/angular-formly@6.10.1.json
+++ b/package-overrides/npm/angular-formly@6.10.1.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "api-check": "^7.0.0",
+    "angular": "^1.2.x || >= 1.4.0-beta.0 || >= 1.5.0-beta.0"
+  }
+}

--- a/registry.json
+++ b/registry.json
@@ -63,6 +63,7 @@
   "any-http-reqwest": "npm:any-http-reqwest",
   "any-promise-angular": "npm:any-promise-angular",
   "any-promise-es6": "npm:any-promise-es6",
+  "api-check": "npm:api-check",
   "army-knife": "npm:army-knife",
   "array-sugar": "github:capaj/array-sugar",
   "assert": "github:jspm/nodelibs-assert",


### PR DESCRIPTION
Didn't notice this override. I'm not certain this is how things work, but basically angular-formly has both of these dependencies listed as peerDependencies and I'm guessing that https://github.com/formly-js/angular-formly/issues/321 is because jspm doesn't resolve peerDependencies correctly.