### PR TITLE
Fixed missing jquery dependency

### DIFF
--- a/package-overrides/github/zurb/bower-foundation@5.0.2.json
+++ b/package-overrides/github/zurb/bower-foundation@5.0.2.json
@@ -2,7 +2,12 @@
   "main": "js/foundation/foundation",
   "shim": {
     "js/foundation/foundation.*": "./foundation",
-    "js/foundation/foundation": ["jquery", "../vendor/custom.modernizr"]
+    "js/foundation/foundation": {
+      "deps": ["jquery", "../vendor/custom.modernizr"]
+    }
+  },
+  "dependencies": {
+    "jquery": "github:components/jquery"
   },
   "ignore": [
     "js/foundation.min.js", 

--- a/package-overrides/github/zurb/bower-foundation@5.5.1.json
+++ b/package-overrides/github/zurb/bower-foundation@5.5.1.json
@@ -8,6 +8,9 @@
       "exports": "Foundation"
     }
   },
+  "dependencies": {
+    "jquery": "github:components/jquery"
+  },
   "ignore": [
     "js/foundation.min.js", 
     "js/vendor/jquery.cookie.js", 


### PR DESCRIPTION
I've noticed Foundation breaks, at least when using a JS component, as jquery is not in the dependencies section. No css included as dependency as I know that topic is a bit controversial...