### PR TITLE
added Greensock

### DIFF
--- a/package-overrides/github/greensock/GreenSock-JS@1.17.0.json
+++ b/package-overrides/github/greensock/GreenSock-JS@1.17.0.json
@@ -1,0 +1,6 @@
+{
+  "main": "TweenMax.js",
+  "directories":{
+    "lib": "src/uncompressed"
+  }
+}

--- a/registry.json
+++ b/registry.json
@@ -160,6 +160,7 @@
   "foundation": "github:zurb/bower-foundation",
   "fs": "github:jspm/nodelibs-fs",
   "golden-layout": "npm:golden-layout",
+  "greensock": "github:greensock/GreenSock-JS",
   "hammer": "github:hammerjs/hammer.js",
   "handlebars": "github:components/handlebars.js",
   "handlebars.js": "github:components/handlebars.js",


### PR DESCRIPTION
Added greensock and changed the main directory.

Reason for changing the main directory is because when requiring the other files in the package one should be able to do so by doing :
```javascript
import TweenLite from "greensock/TweenLite"
import CSSPlugin from "greensock/plugins/CSSPlugin"
```

While it currently is :
```javascript
import TweenLite from "greensock/src/uncompressed/TweenLite"
import CSSPlugin from "greensock/src/uncompressed/plugin/CSSPlugin"
```