### PR TITLE
"lib": "src-noconflict"

### DIFF
--- a/package-overrides/github/ajaxorg/ace-builds@1.1.6.json
+++ b/package-overrides/github/ajaxorg/ace-builds@1.1.6.json
@@ -2,7 +2,7 @@
   "main": "ace",
   "format": "global",
   "directories": {
-    "lib": "src"
+    "lib": "src-noconflict"
   },
   "shim": {
     "ace": {


### PR DESCRIPTION
Some modules rely on `ace.require`, which seems to have its own internal locate/fetch algorithm and doesn't match `cjs`'s `require`.  For example, `ace.require('ace/ext/themelist').themesByName` seems to fetch the file `ace/ext-themelist`, and one might think the equivalent `cjs` line would be `require('ace/ext-themelist').themesByName`, but by that method, `themesByName` is `undefined`.  And even after determining the equivalent `cjs` statement, there will likely be at least a dozen or more others like it, so it's easiest to just use the `noconflict` version.