### PR TITLE
add override for reflect-metadata

### DIFF
--- a/package-overrides/npm/reflect-metadata@0.1.0.json
+++ b/package-overrides/npm/reflect-metadata@0.1.0.json
@@ -1,0 +1,5 @@
+{
+ "map" : {
+   "crypto": "@empty"
+ }
+}


### PR DESCRIPTION
prevents node dependencies from getting bundled up