### PR TITLE
add p5.js to registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -12,6 +12,7 @@
   "jsx": "github:floatdrop/plugin-jsx",
   "less": "github:aaike/jspm-less-plugin",
   "ts": "github:frankwallis/plugin-typescript",
+  "p5": "github:processing/p5.js",
 
   "ace": "github:ajaxorg/ace-builds",
   "adam": "npm:adam",


### PR DESCRIPTION
Request to add p5.js to the registry. This has become one of the more popular libraries for working with canvas and is a port of the very popular java based library Processing. 