### PR TITLE
add Semantic-UI release V2

### DIFF
--- a/package-overrides/github/Semantic-Org/Semantic-UI@2.0.4.json
+++ b/package-overrides/github/Semantic-Org/Semantic-UI@2.0.4.json
@@ -1,0 +1,19 @@
+{
+  "directories": {
+    "lib": "dist"
+  },
+  "main": "semantic",
+  "shim": {
+    "semantic": {
+      "deps": [
+        "jquery",
+        "./semantic.css!"
+      ],
+      "exports": "$"
+    }
+  },
+  "dependencies": {
+    "jquery": "github:components/jquery",
+    "css": "github:systemjs/plugin-css"
+  }
+}


### PR DESCRIPTION
Code doesn't change from previous package-override (except semver it targets), Since Semantic UI v2 adds some really good [features + bugfixes](http://semantic-ui.com/introduction/new.html) I think it's worth keeping it up to date !

Manual Install w/options: 

```javascript
jspm install semantic-ui=github:Semantic-Org/Semantic-UI -o "{
        'directories': {
                'lib': 'dist'
        },
        'main': 'semantic',
        'shim': {
                'semantic': {
                        'deps': [ 'jquery', 'semantic-ui/semantic.css!' ]
                }
        },
        'dependencies': {
                'jquery': 'github:components/jquery',
                'css': 'github:systemjs/plugin-css'
        }
}"
```