### PR TITLE
Add textAngular registry and override

### DIFF
--- a/package-overrides/github/fraywing/textAngular@1.4.2.json
+++ b/package-overrides/github/fraywing/textAngular@1.4.2.json
@@ -1,0 +1,16 @@
+{
+  "main": "dist/textAngular",
+  "files": ["dist/**/*"],
+  "registry": "jspm",
+  "dependencies": {
+    "angular": "^1.3.0",
+    "css": "*",
+    "font-awesome": "^4.0.0",
+    "rangy": "^1.3.0"
+  },
+  "shim": {
+    "dist/textAngular": {
+      "deps": ["rangy", "rangy/rangy-selectionsaverestore", "./textAngularSetup", "./textAngular.css!"]
+    }
+  }
+}

--- a/registry.json
+++ b/registry.json
@@ -341,6 +341,7 @@
   "svg.js" :  "github:wout/svg.js",
   "tabletools": "github:DataTables/TableTools",
   "teo": "npm:teo",
+  "textAngular": "github:fraywing/textAngular",
   "three.js": "github:mrdoob/three.js",
   "three": "github:mrdoob/three.js",
   "threestrap": "github:unconed/threestrap",


### PR DESCRIPTION
Note: textAngular also depends on a sanitization module and I left it up to consumer of this package to additionally load included `textAngular-sanitize` or original `angular-sanitize` or something different. (for more details see: https://github.com/fraywing/textAngular)