### PR TITLE
Fix jquery sizzle path

### DIFF
--- a/package-overrides/github/jquery/jquery@2.1.0-beta2.json
+++ b/package-overrides/github/jquery/jquery@2.1.0-beta2.json
@@ -4,7 +4,7 @@
     "lib": "src"
   },
   "map": {
-    "sizzle": "./src/sizzle/dist/sizzle"
+    "sizzle": "./sizzle/dist/sizzle"
   },
   "ignore": ["src/intro.js", "src/outro.js"]
 }


### PR DESCRIPTION
The current path seems to point towards a non-existing folder?
Seems like a to big an error to go unnoticed, or am I misconfigured back here?