### PR TITLE
socket.io-client is now in socketio, not Automattic.

### DIFF
--- a/package-overrides/github/socketio/socket.io-client@1.3.6.json
+++ b/package-overrides/github/socketio/socket.io-client@1.3.6.json
@@ -1,0 +1,3 @@
+{
+  "main": "socket.io.js"
+}

--- a/registry.json
+++ b/registry.json
@@ -347,7 +347,7 @@
   "skrollr": "github:Prinzhorn/skrollr",
   "snap.svg": "github:adobe-webplatform/Snap.svg",
   "sockjs-client": "github:sockjs/sockjs-client",
-  "socket.io-client": "github:Automattic/socket.io-client",
+  "socket.io-client": "github:socketio/socket.io-client",
   "socket.io-rpc-client": "github:capaj/socket.io-rpc-client",
   "spin": "github:fgnass/spin.js",
   "sprintf-js": "npm:sprintf-js",


### PR DESCRIPTION
Socket.io seem to have changed their github org name to socketio. Github redirects requests so install still works with the old name, but the override is not applied, so the library won't actually load.

This change adds the additional override for the new org name, and updates the registry to point to it.