### PR TITLE
Add `format` to angular-ui-router

### DIFF
--- a/package-overrides/github/angular-ui/ui-router@0.2.12.json
+++ b/package-overrides/github/angular-ui/ui-router@0.2.12.json
@@ -2,6 +2,7 @@
   "directories": {
     "lib": "release"
   },
+  "format": "cjs",
   "main": "angular-ui-router",
   "shim": {
     "angular-ui-router": {


### PR DESCRIPTION
As you can see in [angular-ui-router.js](https://github.com/angular-ui/ui-router/blob/805e69bae319e922e4d3265b7ef565058aaff850/release/angular-ui-router.js#L10), `module.exports` is being used to define the module name for angular.

Setting the format here allows for the following.

```js
import angular from 'angular';
import uiRouter from 'angular-ui-router'

angular.module('app', [uiRouter]);
```