### PR TITLE
Scope materialize to the dist directory

### DIFF
--- a/package-overrides/github/Dogfalo/materialize@0.97.0.json
+++ b/package-overrides/github/Dogfalo/materialize@0.97.0.json
@@ -1,4 +1,7 @@
 {
+  "files": [
+    "dist"
+  ],
   "main": "dist/js/materialize",
   "shim": {
     "dist/js/materialize": {


### PR DESCRIPTION
The entire materialize repo is nearly 30MB, this change means we only put the relevant parts into `jspm_packages`.