### PR TITLE
SASS plugin

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -13,6 +13,7 @@
   "jsx": "github:floatdrop/plugin-jsx",
   "less": "github:aaike/jspm-less-plugin",
   "ts": "github:frankwallis/plugin-typescript",
+  "sass": "github:screendriver/plugin-sass",
 
   "ace": "github:ajaxorg/ace-builds",
   "adam": "npm:adam",


### PR DESCRIPTION
I created a minimal SASS plugin to apply SASS styles directly on the current page:

```js
System.import('./style.scss!');
```

I am a newbie in SystemJS / JSPM and I hope I don't oversight something. It would be great if someone could help with the configuration. I only get it running if I add following to my `config.js` to my consumer projects by hand:

```sh
System.config({
  map: {
    "scss": "jspm:plugin-sass@0.0.1"
  }
});
```

It would be awesome when this could be added automatically so that the consumer only have to make a

```sh
$ jspm install sass
```

and after that everything works out of the box. Unfortunately I don't get it :disappointed: 