### PR TITLE
Add big.js override

### DIFF
--- a/package-overrides/npm/big.js@3.1.3.json
+++ b/package-overrides/npm/big.js@3.1.3.json
@@ -1,0 +1,7 @@
+{
+  "shim": {
+    "big": {
+      "exports": "Big"
+    }
+  }
+}


### PR DESCRIPTION
it says [here](https://github.com/jspm/registry/wiki/Configuring-Packages-for-jspm#shim) that exports are detected automatically, but this didn't work for big.js. This fixed it: `jspm install big.js -o "{ shim: { big: { exports: 'Big' } } }"`. please verify if I've created the override correctly