### PR TITLE
Use npm for c3 library

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -175,7 +175,7 @@
   "cytoscape":"github:cytoscape/cytoscape.js",
   "cytoscape.js":"github:cytoscape/cytoscape.js",
   "d3": "github:mbostock/d3",
-  "c3": "github:masayuki0812/c3",
+  "c3": "npm:c3",
   "datatables": "github:DataTables/DataTables",
   "debug": "github:visionmedia/debug",
   "decimal.js": "github:MikeMcl/decimal.js",


### PR DESCRIPTION
See jspm/jspm-cli#1172 for discussion. This let's you install c3 again.

There is currently a bug preventing the npm version to be used from the JSPM CDN: https://github.com/jspm/npm/issues/99 However this doesn't affect local installs as far as I see and is independent of this pull request.