### PR TITLE
Add knockout-pre-rendered mapping

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -276,6 +276,7 @@
   "klayjs": "github:OpenKieler/klayjs",
   "kl-watch-once": "github:kasperlewau/kl-watch-once",
   "knockout": "github:knockout/knockout",
+  "knockout-pre-rendered": "npm:knockout-pre-rendered",
   "knockout-validation": "github:Knockout-Contrib/Knockout-Validation",
   "leaflet": "github:Leaflet/Leaflet",
   "less.js": "github:distros/less",


### PR DESCRIPTION
This PR adds the mapping for the `knockout-pre-rendered` NPM package.