### PR TITLE
Add Parse JS SDK override to registry

### DIFF
--- a/package-overrides/npm/parse@1.6.5.json
+++ b/package-overrides/npm/parse@1.6.5.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+    "babel-runtime": "^5.8.20"
+  },
+  "devDependencies": {},
+  "files": [
+    "dist/",
+    "lib/browser",
+    "index.js",
+    "LICENSE",
+    "PATENTS"
+  ]
+}


### PR DESCRIPTION
Ignores the modular pieces of the JS SDK, and only pulls in a pre-compiled browser version.