### PR TITLE
npm:moment@2.10.6

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -304,7 +304,7 @@
   "mocha": "npm:mocha",
   "modernizr": "github:Modernizr/Modernizr",
   "module": "github:jspm/nodelibs-module",
-  "moment": "github:moment/moment",
+  "moment": "npm:moment",
   "moment-json-parser": "npm:moment-json-parser",
   "mongoose": "github:gavinaiken/mongoose-browser",
   "moonridge-client": "github:capaj/Moonridge-client",


### PR DESCRIPTION
`moment` changed to use `npm:moment` as discussed in #613 and #616

Package override taken from moment/moment#2577