### PR TITLE
Use npm version of PouchDB

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -344,7 +344,7 @@
   "pixi.js": "npm:pixi.js",
   "poly": "github:cujojs/poly",
   "postal": "npm:postal",
-  "pouchdb": "github:pouchdb/pouchdb",
+  "pouchdb": "npm:pouchdb",
   "pretender": "npm:pretender",
   "prism": "github:LeaVerou/prism",
   "process": "github:jspm/nodelibs-process",


### PR DESCRIPTION
See discussion in https://github.com/pouchdb/pouchdb/issues/4460#issuecomment-149931111. It's much less problematic for PouchDB users to use the npm version rather than the Github version.