### PR TITLE
Add ionic2

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -234,7 +234,7 @@
   "infamous": "npm:infamous",
   "intro": "github:usablica/intro.js",
   "ionic": "github:driftyco/ionic-bower",
-  "ionic2": "npm:ionic@alpha",
+  "ionic2": "ionic-framework",
   "jcrop": "github:tapmodo/Jcrop",
   "jiff": "github:cujojs/jiff",
   "joi": "github:capaj/joi-browser",

--- a/registry.json
+++ b/registry.json
@@ -234,7 +234,7 @@
   "infamous": "npm:infamous",
   "intro": "github:usablica/intro.js",
   "ionic": "github:driftyco/ionic-bower",
-  "ionic2": "ionic-framework",
+  "ionic2": "npm:ionic-framework",
   "jcrop": "github:tapmodo/Jcrop",
   "jiff": "github:cujojs/jiff",
   "joi": "github:capaj/joi-browser",

--- a/registry.json
+++ b/registry.json
@@ -234,6 +234,7 @@
   "infamous": "npm:infamous",
   "intro": "github:usablica/intro.js",
   "ionic": "github:driftyco/ionic-bower",
+  "ionic2": "npm:ionic@alpha",
   "jcrop": "github:tapmodo/Jcrop",
   "jiff": "github:cujojs/jiff",
   "joi": "github:capaj/joi-browser",


### PR DESCRIPTION
Should that work for ionic2 ?. Also I've tried the github:driftyco/ionic2 and is taking the alpha1 version (github:driftyco/ionic2@2.0.0-alpha.1), but the npm one (npm install ionic@alpha) is taking alpha 30, so preferably to take the npm one