### PR TITLE
Create googlediff@0.1.0.json

### DIFF
--- a/package-overrides/npm/googlediff@0.1.0.json
+++ b/package-overrides/npm/googlediff@0.1.0.json
@@ -1,0 +1,4 @@
+{
+  "format": "global",
+  "main": "javascript/diff_match_patch_uncompressed.js"
+}


### PR DESCRIPTION
Trying to `import googlediff from 'googlediff'` resulted in `undefined`.

Looks like `jspm` wrapped the code in [`javascript/diff_match_patch_uncompressed.js`](https://github.com/shimondoodkin/googlediff/blob/master/javascript/diff_match_patch_uncompressed.js) with

```javascript
(function(process) {
    // ...
})(require("process"));
```

Not sure if this override is the correct solution, but it seems to be working.