### PR TITLE
Fix googlediff@0.1.0.json

### DIFF
--- a/package-overrides/npm/googlediff@0.1.0.json
+++ b/package-overrides/npm/googlediff@0.1.0.json
@@ -1,4 +1,11 @@
 {
   "format": "global",
-  "main": "javascript/diff_match_patch_uncompressed.js"
+  "files": [
+    "javascript/diff_match_patch_uncompressed.js"
+  ],
+  "shim": {
+    "javascript/diff_match_patch_uncompressed": {
+      "exports": "diff_match_patch"
+    }
+  }
 }

--- a/package-overrides/npm/googlediff@0.1.0.json
+++ b/package-overrides/npm/googlediff@0.1.0.json
@@ -1,8 +1,6 @@
 {
   "format": "global",
-  "files": [
-    "javascript/diff_match_patch_uncompressed.js"
-  ],
+  "main": "javascript/diff_match_patch_uncompressed.js",
   "shim": {
     "javascript/diff_match_patch_uncompressed": {
       "exports": "diff_match_patch"


### PR DESCRIPTION
Apparently my fix in #634 exported an object literal and not the expected `diff_match_patch` function. This should fix that.