### PR TITLE
dailymotion/hls.js master override added due to latest changes in original repo

### DIFF
--- a/package-overrides/github/dailymotion/hls.js@master.json
+++ b/package-overrides/github/dailymotion/hls.js@master.json
@@ -1,0 +1,3 @@
+{
+  "main": "dist/hls.js"
+}


### PR DESCRIPTION
Some of ```require``` calls will not work in ```master``` due to theirs architecture. 
```master``` override will point ```main``` to ```dist/hls.js``` (in the original package.json ```main: 'src/hls.js'```)