### PR TITLE
repo renamed

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -312,7 +312,7 @@
   "moment": "npm:moment",
   "moment-json-parser": "npm:moment-json-parser",
   "mongoose": "github:gavinaiken/mongoose-browser",
-  "moonridge-client": "github:capaj/Moonridge-client",
+  "moonridge-client": "github:capaj/moonridge-client",
   "mq4-hover-shim": "npm:mq4-hover-shim",
   "msgs": "github:cujojs/msgs",
   "mustache": "github:janl/mustache.js",


### PR DESCRIPTION
JSPM had probems creating public/jspm_packages/github/capaj/moonridge-client@0.9.1.js file, so I ditched the capital letter