### PR TITLE
Update registry for textAngular to add deps for "dist/textAngular-sanitize"

### DIFF
--- a/package-overrides/github/fraywing/textAngular@1.4.2.json
+++ b/package-overrides/github/fraywing/textAngular@1.4.2.json
@@ -11,6 +11,9 @@
   "shim": {
     "dist/textAngular": {
       "deps": ["angular", "rangy", "rangy/rangy-selectionsaverestore", "./textAngularSetup", "./textAngular.css!"]
+    },
+    "dist/textAngular-sanitize": {
+      "deps": [ "angular" ]
     }
   }
 }


### PR DESCRIPTION
The `textAngular-sanitize` is a drop-in replacement for `ngSanitize`.

See here for more info: https://github.com/fraywing/textAngular#where-to-get-it