### PR TITLE
Override ReactJS to load the dist file

### DIFF
--- a/package-overrides/npm/react-@0.14.3.json
+++ b/package-overrides/npm/react-@0.14.3.json
@@ -1,0 +1,3 @@
+{
+  "main": "dist/react.js"
+}


### PR DESCRIPTION
@guybedford this has been discussed in some prior issues about performance of jspm.

Particularly with React jspm has to load a lot of files, so when starting a project with jspm & React you start off with a slow time due to the number of modules that are imported when loading React.

This PR (if I've done the config correctly, which I have tested with `jspm install react -o ...`) tells jspm to load in the one React file instead.

However, @oliverjash pointed out that he likes React being loaded in bit by bit for nicer stack traces and easier debugging of a specific part of React. I would argue that most people don't need to dive into React, and the advanced use is still possible by doing `jspm install react -o "{}"` (I think? - might be nicer to add a `--no-override` flag or similar).

Additionally (and this might be a separate issue in SystemJS/Builder) it would be nice to be able to tell jspm to use a different file when bundling. The `dist/react.min.js` file is specially minified and has some dev code removed so it's more efficient and smaller than a bundle jspm will generate by default. If you could specify which file to use when bundling React that would be really a great help.