### PR TITLE
added package overwrite for lightbox2@2.8.1

### DIFF
--- a/package-overrides/github/lightbox2/lightbox2@2.8.1.json
+++ b/package-overrides/github/lightbox2/lightbox2@2.8.1.json
@@ -1,0 +1,18 @@
+{
+  "main": "dist/js/lightbox.js",
+  "format": "global",
+  "registry": "jspm",
+  "dependencies": {
+    "jquery": "*",
+    "css": "*"
+  },
+  "shim": {
+    "dist/js/lightbox": {
+      "deps": [
+        "jquery",
+        "../css/lightbox.css!"
+      ],
+      "exports": "$"
+    }
+  }
+}


### PR DESCRIPTION
Added the overwrite for the jQuery dependency, the missing css and the missing images. This also  fixes https://github.com/jspm/registry/issues/659
Thanks @guybedford for the hint regarding the package overwrite handling!