### PR TITLE
Create materialize@0.97.3.json to fix issue #680

### DIFF
--- a/package-overrides/github/Dogfalo/materialize@0.97.3.json
+++ b/package-overrides/github/Dogfalo/materialize@0.97.3.json
@@ -1,0 +1,16 @@
+{
+  "main": "js/materialize",
+  "shim": {
+    "js/materialize": {
+      "deps": [
+        "jquery",
+        "../css/materialize.css!"
+      ],
+      "exports": "$"
+    }
+  },
+  "dependencies": {
+    "jquery": "github:components/jquery",
+    "css": "github:systemjs/plugin-css"
+  }
+}


### PR DESCRIPTION
Fixed package override based on new release structure of materialize (refer to issue #680)