### PR TITLE
Redis alias and override

### DIFF
--- a/package-overrides/npm/redis@2.4.2.json
+++ b/package-overrides/npm/redis@2.4.2.json
@@ -1,0 +1,5 @@
+{
+    "map": {
+        "./lib/parsers/hiredis": "@empty"
+    }
+}

--- a/registry.json
+++ b/registry.json
@@ -339,6 +339,7 @@
   "react-dom": "npm:react-dom",
   "react-router": "npm:react-router",
   "readline": "github:jspm/nodelibs-readline",
+  "redis": "npm:redis",
   "redux": "npm:redux",
   "react-redux": "npm:react-redux",
   "reflect-metadata": "npm:reflect-metadata",


### PR DESCRIPTION
The override is needed to prevent a broken feature detection attempt that prevents loading the library at all while `jspm run`ning in NodeJS.