### PR TITLE
Add package override for angular-toasty

### DIFF
--- a/package-overrides/github/invertase/angular-toasty@1.0.4.json
+++ b/package-overrides/github/invertase/angular-toasty@1.0.4.json
@@ -1,0 +1,12 @@
+{
+  "main": "angular-toasty",
+  "shim": {
+    "dist/angular-toasty": {
+      "deps": ["angular"]
+    }
+  },
+  "registry": "jspm",
+  "dependencies": {
+    "angular": "^1.4.8"
+  }
+}


### PR DESCRIPTION
The package [angular-toasty](https://github.com/invertase/angular-toasty) depends on angular and I had to shim it to get it loaded.