### PR TITLE
Adding 'github:eternicode/bootstrap-datepicker' to the registry

### DIFF
--- a/package-overrides/github/eternicode/bootstrap-datepicker@1.5.1.json
+++ b/package-overrides/github/eternicode/bootstrap-datepicker@1.5.1.json
@@ -1,0 +1,19 @@
+{
+	"main": "js/bootstrap-datepicker",
+	"shim": {
+		"js/bootstrap-datepicker": {
+			"deps": [
+				"jquery"
+			],
+			"exports": "$"
+		}
+	},
+	"files": [
+		"js/bootstrap-datepicker.js",
+		"css/bootstrap-datepicker.css"
+	],
+	"dependencies": {
+		"jquery": "github:components/jquery",
+		"bootstrap": "github:twbs/bootstrap"
+	}
+}

--- a/package-overrides/npm/bootstrap-datepicker@1.5.1.json
+++ b/package-overrides/npm/bootstrap-datepicker@1.5.1.json
@@ -1,0 +1,3 @@
+{
+	"format": "global"
+}


### PR DESCRIPTION
I'd like to add [bootstrap-datepicker](https://github.com/eternicode/bootstrap-datepicker) to the JSPM registry.