### PR TITLE
Create angular@1.5.0-rc.2.json

### DIFF
--- a/package-overrides/npm/angular@1.5.0-rc.2.json
+++ b/package-overrides/npm/angular@1.5.0-rc.2.json
@@ -2,10 +2,6 @@
   "format": "global",
   "jspmNodeConversion": false,
   "main": "angular",
-  "files": [
-    "angular.js",
-    "package.json"
-  ],
   "meta": {
     "angular.js": {
       "exports": "angular"

--- a/package-overrides/npm/angular@1.5.0-rc.2.json
+++ b/package-overrides/npm/angular@1.5.0-rc.2.json
@@ -1,0 +1,14 @@
+{
+  "format": "global",
+  "jspmNodeConversion": false,
+  "main": "angular",
+  "files": [
+    "angular.js",
+    "package.json"
+  ],
+  "meta": {
+    "angular.js": {
+      "exports": "angular"
+    }
+  }
+}


### PR DESCRIPTION
Lately I prefer installing Angular via NPM as this seems to be the recommended way (instead of using the bower github repo).

Is the usage here of `jspmNodeConversion` correct? The NPM package is not a jspm-style package but I hope the package overrides are fixing that. Should I also add the `"registry": "jspm"` property?