### PR TITLE
rangy: use cjs instead of global

### DIFF
--- a/package-overrides/github/timdown/rangy-release@1.2.3.json
+++ b/package-overrides/github/timdown/rangy-release@1.2.3.json
@@ -1,5 +1,5 @@
 {
-  "format": "global",
+  "format": "cjs",
   "main": "rangy-core",
   "shim": {
     "rangy-core": {


### PR DESCRIPTION
Fixes imports for rangy submodules, e.g. `import 'rangy/rangy-serializer'`;