### PR TITLE
feat(highcharts/highcharts-dist): add simpler support for highcharts

### DIFF
--- a/package-overrides/github/highcharts/highcharts-dist@4.2.2.json
+++ b/package-overrides/github/highcharts/highcharts-dist@4.2.2.json
@@ -1,0 +1,9 @@
+{
+  "main": "highcharts",
+  "shim": {
+    "highcharts": {
+      "deps": [ "./adapters/standalone-framework" ],
+      "exports": "Highcharts"
+    }
+  }
+}


### PR DESCRIPTION
@guybedford The repository of HighCharts add all modules to the same repository.
This overrides is the simpler version to support JSPM simply, but if you have a better solution, I'll be glad to hear it.
