### PR TITLE
Repoint d3 at npm.

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -197,7 +197,7 @@
   "curl": "github:cujojs/curl",
   "cytoscape":"github:cytoscape/cytoscape.js",
   "cytoscape.js":"github:cytoscape/cytoscape.js",
-  "d3": "github:mbostock/d3",
+  "d3": "npm:d3",
   "d3-legend": "github:susielu/d3-legend",
   "c3": "npm:c3",
   "datatables": "github:DataTables/DataTables",


### PR DESCRIPTION
With 4.0 coming, I’m moving generated files out of the D3 git repository. They’ll be available in npm (and a dedicated Bower git repository, but npm is preferred).

I tested this with `jspm install npm:d3` and it appeared to succeed?
