### PR TITLE
Added override for Bootstrap 3.3.6

### DIFF
--- a/package-overrides/github/twbs/bootstrap@3.3.6.json
+++ b/package-overrides/github/twbs/bootstrap@3.3.6.json
@@ -6,7 +6,8 @@
       "deps": [
         "jquery",
         "../css/bootstrap.css!"
-      ]
+      ],
+      "exports": "$"
     }
   },
   "dependencies": {

--- a/package-overrides/github/twbs/bootstrap@3.3.6.json
+++ b/package-overrides/github/twbs/bootstrap@3.3.6.json
@@ -1,0 +1,16 @@
+{
+  "main": "js/bootstrap",
+  "registry": "jspm",
+  "shim": {
+    "js/bootstrap": {
+      "deps": [
+        "jquery",
+        "../css/bootstrap.css!"
+      ]
+    }
+  },
+  "dependencies": {
+    "jquery": "github:components/jquery",
+    "css": "github:systemjs/plugin-css"
+  }
+}


### PR DESCRIPTION
Provides overrides for Bootstrap 3.3.6.

Note that this differs from [bootstrap@3.3.4.json](https://github.com/jspm/registry/blob/master/package-overrides/github/twbs/bootstrap%403.3.4.json) in that it imports Bootstrap's CSS (as did [bootstrap@3.1.0](https://github.com/jspm/registry/tree/master/package-overrides/github/twbs)).