### PR TITLE
Added overrides Material Design icon font 2.0.4

### DIFF
--- a/package-overrides/github/jossef/material-design-icons-iconfont@2.0.4.json
+++ b/package-overrides/github/jossef/material-design-icons-iconfont@2.0.4.json
@@ -1,0 +1,8 @@
+{
+  "main": "./dist/material-design-icons.css!",
+  "format": "global",
+  "registry": "github",
+  "dependencies": {
+    "css": "github:systemjs/plugin-css"
+  }
+}


### PR DESCRIPTION
Added overrides Material Design icon font library: https://github.com/jossef/material-design-icons-iconfont