### PR TITLE
Create postcss-import@8.0.2.json

### DIFF
--- a/package-overrides/npm/postcss-import@8.0.2.json
+++ b/package-overrides/npm/postcss-import@8.0.2.json
@@ -1,0 +1,10 @@
+"map": {
+  "object-assign": "npm:object-assign@4.0.1",
+  "postcss": "npm:postcss@5.0.19",
+  "postcss-value-parser": "npm:postcss-value-parser@3.3.0",
+  "read-cache": "npm:read-cache@1.0.0",
+  "resolve": "npm:resolve@1.1.7",
+  "./lib/load-content": {
+    "browser": "@empty"
+  }
+}


### PR DESCRIPTION
See here: https://github.com/postcss/postcss-import/issues/181

`load-content` errors out when attempting to run in the browser. This isn't a big deal as it's module is overridden with options passed into PostCSS-Import. However, the module needs to not error out. So, I add an override for the browser environment which ensures an empty response.

QUESTION:

It's not clear to me whether I need to specify all other mapped dependencies in this file, or if I should only specify the one property.

Also, it's not clear to me how I would go about submitting a PR for something like this to postcss-import. I know this registry is supposed to be a temp location, but this seems specific to JSPM and not to their plugin.