### PR TITLE
Adding Chart.js v2.0.0-beta2 override

### DIFF
--- a/package-overrides/github/nnnick/Chart.js@2.0.0-beta2.json
+++ b/package-overrides/github/nnnick/Chart.js@2.0.0-beta2.json
@@ -1,0 +1,12 @@
+{
+    "main": "Chart",
+    "files": ["Chart.js"],
+    "shim": {
+        "Chart.js": {
+             "deps": ["moment"]
+        }
+    },
+    "dependencies": {
+        "moment": "*"
+    }
+}


### PR DESCRIPTION
moment is needed as a dependency for chart.js v2 beta in order for it to load properly