### PR TITLE
Fix shim path for angular-ui-select

### DIFF
--- a/package-overrides/github/angular-ui/ui-select@0.14.2.json
+++ b/package-overrides/github/angular-ui/ui-select@0.14.2.json
@@ -6,7 +6,7 @@
   "main": "dist/select",
   "registry": "jspm",
   "shim": {
-    "select": {
+    "dist/select": {
       "deps": [
         "angular",
         "./dist/select.css!"


### PR DESCRIPTION
After removing the `directories.lib` override in https://github.com/jspm/registry/commit/1ad887e48c2d26e41c50b61d26594094ea649e5f, the path for the main shim is incorrect and is not applying the deps overrides