### PR TITLE
Add coffee-script@1.10.0.json override

### DIFF
--- a/package-overrides/npm/coffee-script@1.10.0.json
+++ b/package-overrides/npm/coffee-script@1.10.0.json
@@ -1,0 +1,5 @@
+{
+  "map": {
+    "child_process": "@empty"
+  }
+}


### PR DESCRIPTION
This PR adds an override for the `npm:coffee-script` package to disable the `child_process` module. With this override `coffee-script` can be required inside a SystemJS environment without it [throwing an error](https://github.com/jspm/nodelibs-child_process/blob/master/child_process.js) because of it requiring `child_process`. 

The only place where `child_process` is required inside CoffeeScript is within `CoffeeScript.register()` (which is used to patch node's module system to understand how to require `.coffee` files) which shouldn't be of any interest for a SystemJS user anyway.

This PR enables the usage of a `npm:coffee-script` dependency inside the [`system-coffee` plugin](https://github.com/forresto/system-coffee).
Refs: https://github.com/forresto/system-coffee/pull/11
Fixes: https://github.com/forresto/system-coffee/issues/2