### PR TITLE
Add “deps” to ace editor components

### DIFF
--- a/package-overrides/github/ajaxorg/ace-builds@1.1.6.json
+++ b/package-overrides/github/ajaxorg/ace-builds@1.1.6.json
@@ -7,6 +7,11 @@
   "shim": {
     "ace": {
       "exports": "ace"
+    },
+    "*": {
+      "deps": [
+        "ace/ace"
+      ]
     }
   }
 }


### PR DESCRIPTION
Allows to import language components ahead of time, to include them in bundles:
```
import ace from 'ace';
import 'ace/mode-javascript.js';
import 'ace/theme-twilight.js';
```

It doesn’t solves the issue with workers components however.