### PR TITLE
add package override for npm:materialize-css

### DIFF
--- a/package-overrides/npm/materialize-css@0.97.5.json
+++ b/package-overrides/npm/materialize-css@0.97.5.json
@@ -1,0 +1,23 @@
+{
+  "format": "global",
+  "files": [
+    "dist/js/materialize.js",
+    "dist/css/materialize.css",
+    "dist/font/**/*",
+    "extras/noUiSlider/*"
+  ],
+  "main": "dist/js/materialize",
+  "dependencies": {
+    "jquery": "github:components/jquery",
+    "css": "github:systemjs/plugin-css"
+  },
+    "shim": {
+        "dist/js/materialize": {
+        "deps": [
+            "jquery",
+            "../css/materialize.css!"
+        ],
+        "exports": "$"
+        }
+    }
+}


### PR DESCRIPTION
Might be useful for other people that have issues with installing materialize-css with jspm. 

According to this post (https://github.com/Dogfalo/materialize/issues/1208) they won't maintain this in the main package.

Also have a scoped npm package (https://www.npmjs.com/package/@eriklieben/materialize-css), but not sure if that is the best way to install it. Currently it is already ahead of the official release, because I needed bug fixes that are not in the release 0.97.5
