### PR TITLE
Esprima does not need the `fs` and `process` shims

### DIFF
--- a/package-overrides/npm/esprima@2.7.2.json
+++ b/package-overrides/npm/esprima@2.7.2.json
@@ -1,0 +1,3 @@
+{
+  "jspmNodeConversion": false
+}


### PR DESCRIPTION
It is standalone and packaged as a UMD.

Fixes https://github.com/jspm/registry/issues/839
Reference: https://github.com/jquery/esprima/issues/1486