### PR TITLE
fix(typescript): fix for '_os.platform is not a function' error

### DIFF
--- a/package-overrides/npm/typescript@1.8.0.json
+++ b/package-overrides/npm/typescript@1.8.0.json
@@ -1,0 +1,11 @@
+{
+  "browser": {},
+  "map": {
+    "buffer": "@empty",
+    "child_process": "@empty",
+    "fs": "@empty",
+    "path": "@empty",
+    "process": "@empty",
+    "readline": "@empty"
+  }
+}


### PR DESCRIPTION
as discussed in https://github.com/jspm/jspm-cli/issues/1662