### PR TITLE
Added a flag to avoid the following error when installing npm:materia…

### DIFF
--- a/package-overrides/npm/materialize-css@0.97.5.json
+++ b/package-overrides/npm/materialize-css@0.97.5.json
@@ -5,13 +5,14 @@
     "jquery": "github:components/jquery",
     "css": "github:systemjs/plugin-css"
   },
-    "shim": {
-        "dist/js/materialize": {
-        "deps": [
-            "jquery",
-            "../css/materialize.css!"
-        ],
-        "exports": "$"
-        }
+  "shim": {
+    "dist/js/materialize": {
+      "deps": [
+        "jquery",
+        "../css/materialize.css!"
+      ],
+      "exports": "$"
     }
+  },
+  "jspmNodeConversion": false
 }


### PR DESCRIPTION
Fix for https://github.com/jspm/registry/issues/891

Added a flag to avoid the following error when installing npm:materialize-css : "Error on processPackageConfig. Package.json dependency jquery set to github:components/jquery, which is not a valid dependency format for npm. It's advisable to publish jspm-style packages to GitHub or another registry so conventions are clear."
