### PR TITLE
Remove directories.lib override from bootstrap@4.0.0-alpha.2

### DIFF
--- a/package-overrides/github/twbs/bootstrap@4.0.0-alpha.2.json
+++ b/package-overrides/github/twbs/bootstrap@4.0.0-alpha.2.json
@@ -1,12 +1,9 @@
 {
-  "main": "js/bootstrap",
+  "main": "dist/js/bootstrap",
   "files": null,
   "ignore": [
     "dist/js/npm"
   ],
-  "directories": {
-    "lib": "dist"
-  },
   "shim": {
     "js/bootstrap": {
       "deps": [

--- a/package-overrides/github/twbs/bootstrap@4.0.0-alpha.2.json
+++ b/package-overrides/github/twbs/bootstrap@4.0.0-alpha.2.json
@@ -4,6 +4,9 @@
   "ignore": [
     "dist/js/npm"
   ],
+  "directories": {
+    "lib": "."
+  },
   "shim": {
     "js/bootstrap": {
       "deps": [


### PR DESCRIPTION
This is needed to get the sass files in the bootstrap distribution.