### PR TITLE
Fix _os.platform is not a function error

### DIFF
--- a/package-overrides/npm/typescript@1.9.0-dev.json
+++ b/package-overrides/npm/typescript@1.9.0-dev.json
@@ -4,7 +4,6 @@
     "buffer": "@empty",
     "child_process": "@empty",
     "fs": "@empty",
-    "os": "@empty",
     "path": "@empty",
     "process": "@empty",
     "readline": "@empty"


### PR DESCRIPTION
This fixes the `_os.platform is not a function` exception which occurs when attempting to use the bundle command in jspm@0.17.0-beta. I experimented with local overrides and this did the trick. @frankwallis, @guybedford, does this look right? I was able to reproduce the issue on multiple systems. typescript@1.8.10 works fine with jspm@0.17.0-beta, and typescript@1.9.0-dev works fine when building with jspm@0.16.35.