### PR TITLE
correct protobuf.js alias inline with npm

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -441,7 +441,7 @@
   "pretender": "npm:pretender",
   "prism": "github:LeaVerou/prism",
   "process": "github:jspm/nodelibs-process",
-  "protobuf": "github:dcodeIO/protobuf.js",
+  "protobufjs": "github:dcodeIO/protobuf.js",
   "punycode": "github:jspm/nodelibs-punycode",
   "purecss": "npm:purecss",
   "puremvc-standard": "github:PureMVC/puremvc-typescript-standard-framework",


### PR DESCRIPTION
node module for this package is "protobufjs", "protobuf" relates to different project. Also typings has this as "protobufjs".  

Sorry for the faff on this, it only just occurred to me that name conflict between jspm and npm package names would make targeting commonjs and system all the more harder. 