### PR TITLE
Fix directories and jquery in bootstrap 4

### DIFF
--- a/package-overrides/github/twbs/bootstrap@4.0.0-alpha.2.json
+++ b/package-overrides/github/twbs/bootstrap@4.0.0-alpha.2.json
@@ -1,14 +1,14 @@
 {
-  "main": "js/bootstrap",
+  "main": "dist/js/bootstrap",
   "files": null,
   "ignore": [
     "dist/js/npm"
   ],
   "directories": {
-    "lib": "dist"
+    "lib": "."
   },
   "shim": {
-    "js/bootstrap": {
+    "dist/js/bootstrap": {
       "deps": [
         "jquery",
         "tether"
@@ -17,7 +17,7 @@
     }
   },
   "dependencies": {
-    "jquery": "*",
+    "jquery": "npm:jquery@^2.2.4",
     "tether": "github:HubSpot/tether@^1.1.1"
   }
 }


### PR DESCRIPTION
- Bootstrap 4 is incompatible with jquery 3+
- Set lib to . so that sass files are installed

Test using this repo: https://github.com/jakeNiemiec/jspm_bootstrap