### PR TITLE
fix(Semantic-UI@2.0.4.json): Maintain jQuery 2.x.x in Semantic UI

### DIFF
--- a/package-overrides/github/Semantic-Org/Semantic-UI@2.0.4.json
+++ b/package-overrides/github/Semantic-Org/Semantic-UI@2.0.4.json
@@ -14,7 +14,7 @@
   },
   "registry": "jspm",
   "dependencies": {
-    "jquery": "*",
+    "jquery": "^2.1.4",
     "css": "*"
   }
 }


### PR DESCRIPTION
Currently, "*" dependency pulls in jQuery 3.x.x, which breaks Semantic UI. This restores the original "^2.1.4" behavior.

closes https://github.com/jspm/jspm-cli/issues/1918