### PR TITLE
Lock bootstrap 3.3.6 to use jQuery 2.x

### DIFF
--- a/package-overrides/github/twbs/bootstrap@3.3.6.json
+++ b/package-overrides/github/twbs/bootstrap@3.3.6.json
@@ -1,0 +1,24 @@
+{
+  "main": "js/bootstrap",
+  "shim": {
+    "js/bootstrap": {
+      "deps": ["jquery"],
+      "exports": "$"
+    }
+  },
+  "dependencies": {
+    "jquery": "2"
+  },
+  "files": ["dist", "fonts", "js", "css", "less", "grunt", "LICENSE"],
+  "systemjs": {
+    "main": "dist/js/bootstrap.js",
+    "modules": {
+      "dist/js/bootstrap.js": {
+        "deps": [
+          "jquery"
+        ],
+        "exports": "$"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Bootstrap complains if it gets jQuery 3.x as a dep. This will lock it to 2.x