### PR TITLE
Update overrides to overwrite bad "map".

### DIFF
--- a/package-overrides/npm/aws-sdk@2.4.0.json
+++ b/package-overrides/npm/aws-sdk@2.4.0.json
@@ -6,5 +6,6 @@
     "dist/aws-sdk": {
       "exports": "AWS"
     }
-  }
+  },
+  "map": {}
 }


### PR DESCRIPTION
If you don't set "map" to {}, you get

```json
"map": { "browser": "lib/browser.js" }
```

Which hopelessly breaks everything, as "lib/browser.js" contains calls to `require` that the browser can't handle.

`jspm run app` still errors, but at least the browser build works again.