### PR TITLE
Create fms-js@0.2.7

### DIFF
--- a/package-overrides/npm/fms-js@0.2.7.json
+++ b/package-overrides/npm/fms-js@0.2.7.json
@@ -1,0 +1,3 @@
+{
+  "ignore": ["examples", "test"]
+}


### PR DESCRIPTION
This package has an 11mb binary file in the tests folder, which jspm-npm tries to detect module formats on, leading traceur to use up gigabytes of memory eventually crashing node