### PR TITLE
Adding updated angular-nvd3 override

### DIFF
--- a/package-overrides/github/krispo/angular-nvd3@1.0.7.json
+++ b/package-overrides/github/krispo/angular-nvd3@1.0.7.json
@@ -1,8 +1,5 @@
 {
-  "main": "dist/angular-nvd3.js", 
-  "files": [
-    "dist/angular-nvd3.js"
-  ],
+  "main": "dist/angular-nvd3.js",
   "registry": "jspm",
   "format": "global",
   "dependencies": {

--- a/package-overrides/github/krispo/angular-nvd3@1.0.7.json
+++ b/package-overrides/github/krispo/angular-nvd3@1.0.7.json
@@ -1,0 +1,18 @@
+{
+  "main": "dist/angular-nvd3.js", 
+  "files": [
+    "dist/angular-nvd3.js"
+  ],
+  "registry": "jspm",
+  "format": "global",
+  "dependencies": {
+    "angular": "^1",
+    "nvd3": "npm:nvd3@^1.7.1"
+  },
+  "shim": {
+    "dist/angular-nvd3": [
+      "angular",
+      "nvd3"
+    ]
+  }  
+}


### PR DESCRIPTION
The 1.0.2 angular-nvd3 override isn't working for me.  It works once I add the `main` property and add `nvd3` as a shim dependency.