### PR TITLE
Update moment@2.0.0.json

### DIFF
--- a/package-overrides/npm/moment@2.0.0.json
+++ b/package-overrides/npm/moment@2.0.0.json
@@ -1,3 +1,4 @@
 {
-  "jspmNodeConversion": false
+  "jspmNodeConversion": false,
+  "format": "umd"
 }


### PR DESCRIPTION
Fixes the "AMD module did not define" error that sometimes occurs when trying to import moment.

Recreate issue:
```
$ node -e "require('jspm').import('moment').then(console.log.bind(console)).catch(console.log.bind(console))"

{ (SystemJS) AMD module /media/Data/dev/work/encurate/ecm-api/functions/authorizer/jspm_packages/npm/moment@2.14.1/moment.js did not define
        TypeError: AMD module /media/Data/dev/work/encurate/ecm-api/functions/authorizer/jspm_packages/npm/moment@2.14.1/moment.js did not define
        Error loading /media/Data/dev/work/encurate/ecm-api/functions/authorizer/jspm_packages/npm/moment@2.14.1/moment.js
  originalErr:
   TypeError: AMD module file:///media/Data/dev/work/encurate/ecm-api/functions/authorizer/jspm_packages/npm/moment@2.14.1/moment.js did not define
       at SystemJSNodeLoader.<anonymous> (/media/Data/dev/work/encurate/ecm-api/functions/authorizer/node_modules/systemjs/dist/system.src.js:4347:19)
       at SystemJSNodeLoader.instantiate (/media/Data/dev/work/encurate/ecm-api/functions/authorizer/node_modules/systemjs/dist/system.src.js:4619:28)
       at /media/Data/dev/work/encurate/ecm-api/functions/authorizer/node_modules/systemjs/dist/system.src.js:433:33 }
```

Once the format override is added things work. Or appear to at least.

Strangely, the error only occurs when trying to import from the command line using `node -e`. If I load up the node REPL and run the exact same code, no error occurs.