### PR TITLE
Mocha 3 support

### DIFF
--- a/package-overrides/npm/mocha@3.0.0.json
+++ b/package-overrides/npm/mocha@3.0.0.json
@@ -1,0 +1,46 @@
+{
+  "main": "./mocha.js",
+  "jspmNodeConversion": false,
+  "meta": {
+    "mocha.js": {
+      "deps": [
+        "./mocha.css!"
+      ],
+      "exports": "Mocha",
+      "format": "global"
+    }
+  },
+  "shim": {
+    "mocha": {
+      "exports": "mocha",
+      "deps": [
+        "./mocha.css!"
+      ]
+    }
+  },
+  "dependencies": {
+    "css": "*",
+    "debug": "^2.2.0"
+  },
+  "registry": "jspm",
+  "map": {
+    "./mocha.js": {
+      "node": "./lib/mocha.js"
+    },
+    "escape-string-regexp": "@empty",
+    "growl": "@empty",
+    "./lib/reporters.js": "./lib/reporters/index.js",
+    "./lib/interfaces.js": "./lib/interfaces/index.js",
+    "glob": "@empty",
+    "to-iso-string": "@empty",
+    "mkdirp": "@empty",
+    "jade": "@empty",
+    "diff": "@empty",
+    "supports-color": "@empty",
+    "path": "@node/path",
+    "fs": "@node/fs",
+    "util": "@node/util",
+    "events": "@node/events",
+    "tty": "@node/tty"
+  }
+}


### PR DESCRIPTION
Mocha 3 has recently been released:
https://github.com/mochajs/mocha/blob/master/CHANGELOG.md

As the registry uses semver to resolve override, this commit adds
a new file `mocha@3.0.0.json` which is basically just a copy of
`mocha@2.5.3.json`.

Note that I've only tested this is the browser and not in Node.js