### PR TITLE
feat(openlayers): add npm:openlayers override

### DIFF
--- a/package-overrides/npm/openlayers@3.17.1.json
+++ b/package-overrides/npm/openlayers@3.17.1.json
@@ -1,0 +1,21 @@
+{
+    "dependencies": {
+        "async": "2.0.1",
+        "browserify": "13.1.0",
+        "closure-util": "1.15.0",
+        "derequire": "2.0.3",
+        "fs-extra": "0.30.0",
+        "glob": "7.0.5",
+        "handlebars": "4.0.5",
+        "marked": "0.3.6",
+        "metalsmith": "2.1.0",
+        "metalsmith-layouts": "1.6.5",
+        "nomnom": "1.8.1",
+        "pbf": "2.0.1",
+        "pixelworks": "1.1.0",
+        "rbush": "2.0.1",
+        "temp": "0.8.3",
+        "vector-tile": "1.3.0",
+        "walk": "2.3.9"
+    }
+}


### PR DESCRIPTION
Installing openlayers from npm currently fails with `jspm@0.17.0-beta.25` with the following error:
```
err  Error on processPackageConfig
npm dependency format https://github.com/hegemonic/taffydb/tarball/7d100bcee0e997ee4977e273cdce60bd8933050e not supported by jspm.
```

This override removes the `jsdoc` dependency from the openlayers dependencies.