### PR TITLE
Bootstrap 3.3.7 supports jQuery 3

### DIFF
--- a/package-overrides/github/twbs/bootstrap@3.3.7.json
+++ b/package-overrides/github/twbs/bootstrap@3.3.7.json
@@ -1,0 +1,12 @@
+{
+  "main": "dist/js/bootstrap.js",
+  "shim": {
+    "dist/js/bootstrap": {
+      "deps": ["jquery"],
+      "exports": "$"
+    }
+  },
+  "dependencies": {
+    "jquery": "*"
+  }
+}


### PR DESCRIPTION
Bootstrap 3.3.7 jQuery requirements:  [Bootstrap's JavaScript requires jQuery version 1.9.1 or higher, but lower than version 4](https://github.com/twbs/bootstrap/blob/0b9c4a4007c44201dce9a6cc1a38407005c26c86/dist/js/bootstrap.js#L15).