### PR TITLE
 	add override for material-design-lite

### DIFF
--- a/package-overrides/github/google/material-design-lite@1.2.0.json
+++ b/package-overrides/github/google/material-design-lite@1.2.0.json
@@ -1,0 +1,3 @@
+{
+  "main": "material.js"
+}


### PR DESCRIPTION
`material-design-lite`'s `main` field is not recognized from github endpoint.