### PR TITLE
Fix import of "babel-core" w/ debug/node override

### DIFF
--- a/package-overrides/npm/debug@2.2.0.json
+++ b/package-overrides/npm/debug@2.2.0.json
@@ -7,6 +7,9 @@
     "./browser.js": {
       "node": "./node.js"
     },
+    "./node.js": {
+      "browser": "./browser.js"
+    },
     "fs": "@node/fs",
     "net": "@node/net",
     "tty": "@node/tty",


### PR DESCRIPTION
Babel imports "debug/node" which causes "(SystemJS) Error loading @node/tty. Can only load node core modules in Node" https://github.com/babel/babel/blob/master/packages/babel-core/src/transformation/file/logger.js