### PR TITLE
Added support for npm:bootstrap@3.3.7

### DIFF
--- a/package-overrides/npm/bootstrap@3.3.7.json
+++ b/package-overrides/npm/bootstrap@3.3.7.json
@@ -1,0 +1,15 @@
+{
+  "main": "js/bootstrap",
+  "directories": {
+    "lib": "dist"
+  },
+  "shim": {
+    "js/bootstrap": {
+      "deps": [
+        "jquery",
+      ],
+      "exports": "$"
+    }
+  },
+  "files": [ "dist" ]
+}


### PR DESCRIPTION
Now npm:bootstrap includes the dist folder, not the source files