### PR TITLE
feat(@angular/*): use different main entry in production mode

### DIFF
--- a/package-overrides/npm/@angular/common@2.0.0.json
+++ b/package-overrides/npm/@angular/common@2.0.0.json
@@ -1,6 +1,10 @@
 {
   "meta": {
+    "index.js": {
+      "format": "esm"
+    },
     "src/*.js": {
+      "format": "esm",
       "deps": [
         "reflect-metadata",
         "zone.js"
@@ -8,7 +12,10 @@
     }
   },
   "map": {
-    "@angular/common": ".",
+    "./bundles/common.umd.js": {
+      "production": "./index.js",
+      "~production": "./bundles/common.umd.js"
+    },
     "./testing": "./bundles/common-testing.umd.js"
   }
 }

--- a/package-overrides/npm/@angular/compiler@2.0.0.json
+++ b/package-overrides/npm/@angular/compiler@2.0.0.json
@@ -1,6 +1,10 @@
 {
   "meta": {
+    "index.js": {
+      "format": "esm"
+    },
     "src/*.js": {
+      "format": "esm",
       "deps": [
         "reflect-metadata",
         "zone.js"
@@ -8,7 +12,10 @@
     }
   },
   "map": {
-    "@angular/compiler": ".",
+    "./bundles/compiler.umd.js": {
+      "production": "./index.js",
+      "~production": "./bundles/compiler.umd.js"
+    },
     "./testing": "./bundles/compiler-testing.umd.js"
   }
 }

--- a/package-overrides/npm/@angular/core@2.0.0.json
+++ b/package-overrides/npm/@angular/core@2.0.0.json
@@ -1,6 +1,10 @@
 {
   "meta": {
+    "index.js": {
+      "format": "esm"
+    },
     "src/*.js": {
+      "format": "esm",
       "deps": [
         "reflect-metadata",
         "zone.js"
@@ -8,7 +12,10 @@
     }
   },
   "map": {
-    "@angular/core": ".",
+    "./bundles/core.umd.js": {
+      "production": "./index.js",
+      "~production": "./bundles/core.umd.js"
+    },
     "./testing": "./bundles/core-testing.umd.js"
   }
 }

--- a/package-overrides/npm/@angular/http@2.0.0.json
+++ b/package-overrides/npm/@angular/http@2.0.0.json
@@ -1,6 +1,10 @@
 {
   "meta": {
+    "index.js": {
+      "format": "esm"
+    },
     "src/*.js": {
+      "format": "esm",
       "deps": [
         "reflect-metadata",
         "zone.js"
@@ -8,7 +12,10 @@
     }
   },
   "map": {
-    "@angular/http": ".",
+    "./bundles/http.umd.js": {
+      "production": "./index.js",
+      "~production": "./bundles/http.umd.js"
+    },
     "./testing": "./bundles/http-testing.umd.js"
   }
 }

--- a/package-overrides/npm/@angular/platform-browser-dynamic@2.0.0.json
+++ b/package-overrides/npm/@angular/platform-browser-dynamic@2.0.0.json
@@ -1,6 +1,10 @@
 {
   "meta": {
+    "index.js": {
+      "format": "esm"
+    },
     "src/*.js": {
+      "format": "esm",
       "deps": [
         "reflect-metadata",
         "zone.js"
@@ -8,7 +12,10 @@
     }
   },
   "map": {
-    "@angular/platform-browser-dynamic": ".",
+    "./bundles/platform-browser-dynamic.umd.js": {
+      "production": "./index.js",
+      "~production": "./bundles/platform-browser-dynamic.umd.js"
+    },
     "./testing": "./bundles/platform-browser-dynamic-testing.umd.js"
   }
 }

--- a/package-overrides/npm/@angular/platform-browser@2.0.0.json
+++ b/package-overrides/npm/@angular/platform-browser@2.0.0.json
@@ -1,6 +1,10 @@
 {
   "meta": {
+    "index.js": {
+      "format": "esm"
+    },
     "src/*.js": {
+      "format": "esm",
       "deps": [
         "reflect-metadata",
         "zone.js"
@@ -8,7 +12,10 @@
     }
   },
   "map": {
-    "@angular/platform-browser": ".",
+    "./bundles/platform-browser.umd.js": {
+      "production": "./index.js",
+      "~production": "./bundles/platform-browser.umd.js"
+    },
     "./testing": "./bundles/platform-browser-testing.umd.js"
   }
 }

--- a/package-overrides/npm/@angular/router@3.0.0-rc.1.json
+++ b/package-overrides/npm/@angular/router@3.0.0-rc.1.json
@@ -1,6 +1,10 @@
 {
   "meta": {
+    "index.js": {
+      "format": "esm"
+    },
     "src/*.js": {
+      "format": "esm",
       "deps": [
         "reflect-metadata",
         "zone.js"
@@ -8,7 +12,10 @@
     }
   },
   "map": {
-    "@angular/router": ".",
+    "./bundles/router.umd.js": {
+      "production": "./index.js",
+      "~production": "./bundles/router.umd.js"
+    },
     "./testing": "./bundles/router-testing.umd.js"
   }
 }


### PR DESCRIPTION
When setting production to true, the main entry is set to the index.js file.
The file (like the other files in the src directory) is an ES5 JavaScript file
with ES6 module format. Using this file instead of the UMD bundle allows
for tree-shaking when building the package in production mode using
rollup.