### PR TITLE
Use same override for svgo@0.7.1 as 0.6.1

### DIFF
--- a/package-overrides/npm/svgo@0.7.1.json
+++ b/package-overrides/npm/svgo@0.7.1.json
@@ -1,0 +1,47 @@
+{
+  "meta": {
+    "lib/svgo/config.js": {
+      "deps": [
+        "../../plugins/removeDoctype",
+        "../../plugins/removeXMLProcInst",
+        "../../plugins/removeComments",
+        "../../plugins/removeMetadata",
+        "../../plugins/removeEditorsNSData",
+        "../../plugins/cleanupAttrs",
+        "../../plugins/minifyStyles",
+        "../../plugins/convertStyleToAttrs",
+        "../../plugins/cleanupIDs",
+        "../../plugins/removeRasterImages",
+        "../../plugins/removeUselessDefs",
+        "../../plugins/cleanupNumericValues",
+        "../../plugins/cleanupListOfValues",
+        "../../plugins/convertColors",
+        "../../plugins/removeUnknownsAndDefaults",
+        "../../plugins/removeNonInheritableGroupAttrs",
+        "../../plugins/removeUselessStrokeAndFill",
+        "../../plugins/removeViewBox",
+        "../../plugins/cleanupEnableBackground",
+        "../../plugins/removeHiddenElems",
+        "../../plugins/removeEmptyText",
+        "../../plugins/convertShapeToPath",
+        "../../plugins/moveElemsAttrsToGroup",
+        "../../plugins/moveGroupAttrsToElems",
+        "../../plugins/collapseGroups",
+        "../../plugins/convertPathData",
+        "../../plugins/convertTransform",
+        "../../plugins/removeEmptyAttrs",
+        "../../plugins/removeEmptyContainers",
+        "../../plugins/mergePaths",
+        "../../plugins/removeUnusedNS",
+        "../../plugins/transformsWithOnePath",
+        "../../plugins/sortAttrs",
+        "../../plugins/removeTitle",
+        "../../plugins/removeDesc",
+        "../../plugins/removeDimensions",
+        "../../plugins/removeAttrs",
+        "../../plugins/addClassesToSVGElement",
+        "../../plugins/removeStyleElement"
+      ]
+    }
+  }
+}

--- a/package-overrides/npm/svgo@0.7.1.json
+++ b/package-overrides/npm/svgo@0.7.1.json
@@ -40,7 +40,10 @@
         "../../plugins/removeDimensions",
         "../../plugins/removeAttrs",
         "../../plugins/addClassesToSVGElement",
-        "../../plugins/removeStyleElement"
+        "../../plugins/removeStyleElement",
+        "../../plugins/removeXMLNS",
+        "../../plugins/removeElementsByAttr",
+        "../../plugins/addAttributesToSVGElement"
       ]
     }
   }


### PR DESCRIPTION
svgo released a new version that still has not fixed https://github.com/svg/svgo/issues/504. Since the dependencies are not statically declared, we need this override. See the [similar override for 0.6.1](https://github.com/jspm/registry/blob/master/package-overrides/npm/svgo%400.6.1.json). This pull request adds three more plugins that have been written that were not part of 0.6.1:

"../../plugins/removeXMLNS"
"../../plugins/removeElementsByAttr"
"../../plugins/addAttributesToSVGElement"