### PR TITLE
Add an override for typescript 2.1.0 specifying source-map-support

### DIFF
--- a/package-overrides/npm/typescript@2.1.0.json
+++ b/package-overrides/npm/typescript@2.1.0.json
@@ -1,0 +1,14 @@
+{
+  "browser": {},
+  "map": {
+    "buffer": "@empty",
+    "child_process": "@empty",
+    "fs": "@empty",
+    "path": "@empty",
+    "process": "@empty",
+    "readline": "@empty"
+  },
+  "dependencies": {
+    "source-map-support": "*"
+  }
+}


### PR DESCRIPTION
Add an override for typescript 2.1.0 specifying source-map-support as a dependency to resolve several recent issues.