### PR TITLE
Add override for angular-ui-router@0.3.2

### DIFF
--- a/package-overrides/github/angular-ui/angular-ui-router-bower@0.3.2.json
+++ b/package-overrides/github/angular-ui/angular-ui-router-bower@0.3.2.json
@@ -1,0 +1,19 @@
+{  
+  "packages": {
+    "github:angular-ui/angular-ui-router-bower@0.3.2": {
+      "map": {
+        "angular": "github:angular/bower-angular@1.6.0"
+      },
+      "meta": {
+        "*": {
+          "globals": {
+            "angular": "angular"
+          },
+          "deps": [
+            "angular"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/package-overrides/github/angular-ui/angular-ui-router-bower@0.3.2.json
+++ b/package-overrides/github/angular-ui/angular-ui-router-bower@0.3.2.json
@@ -1,19 +1,12 @@
 {  
-  "packages": {
-    "github:angular-ui/angular-ui-router-bower@0.3.2": {
-      "map": {
-        "angular": "github:angular/bower-angular@1.6.0"
+  "meta": {
+    "*": {
+      "globals": {
+        "angular": "angular"
       },
-      "meta": {
-        "*": {
-          "globals": {
-            "angular": "angular"
-          },
-          "deps": [
-            "angular"
-          ]
-        }
-      }
+      "deps": [
+        "angular"
+      ]
     }
   }
 }


### PR DESCRIPTION
See https://github.com/jspm/jspm-cli/issues/2197.

Version 0.3.2 of ui-router was [published last month](https://github.com/angular-ui/ui-router/releases/tag/0.3.2), and each version of the library has to have a shim/globals configuration since it depends on the angular global 