### PR TITLE
npm:debug update override to support 2.5.1

### DIFF
--- a/package-overrides/npm/debug@2.5.1.json
+++ b/package-overrides/npm/debug@2.5.1.json
@@ -1,0 +1,12 @@
+
+{
+  "main": "src/browser.js",
+  "jspmNodeConversion": false,
+  "format": "cjs",
+  "map": {
+    "fs": "@empty",
+    "net": "@empty",
+    "tty": "@empty",
+    "util": "@empty"
+  }
+}


### PR DESCRIPTION
to resolve https://github.com/jspm/jspm-cli/issues/2204 and https://github.com/visionmedia/debug/issues/394