### PR TITLE
Fix angular-ui-router@0.3.1 override

### DIFF
--- a/package-overrides/github/angular-ui/angular-ui-router-bower@0.3.1.json
+++ b/package-overrides/github/angular-ui/angular-ui-router-bower@0.3.1.json
@@ -1,7 +1,7 @@
 {
   "main": "release/angular-ui-router.js",
   "shim": {
-    "release/angular-ui-router.js": {
+    "release/angular-ui-router": {
       "deps": ["angular"]
     }
   },


### PR DESCRIPTION
See https://github.com/jspm/jspm-cli/pull/2200 and https://github.com/jspm/jspm-cli/issues/2197#issuecomment-269520408 for discussion. The `.js` extension should not be included in `shim` configurations.

I have tested this by doing `jspm install angular-ui-router@0.3.1 -o '{"main": "release/angular-ui-router.js", "shim": {"release/angular-ui-router": {"deps": ["angular"]}},"dependencies": {"angular": "*"}}'` locally and verified that it works. Without this change, ui-router@0.3.1 does not work in jspm@0.17