### PR TITLE
feat(nya-bootstrap-select): add github version of override

### DIFF
--- a/package-overrides/github/lordfriend/nya-bootstrap-select@2.1.9.json
+++ b/package-overrides/github/lordfriend/nya-bootstrap-select@2.1.9.json
@@ -1,0 +1,13 @@
+{
+  "main": "dist/js/nya-bs-select.js",
+  "dependencies": {
+    "css": "jspm:css@*"
+  },
+  "shim": {
+    "dist/js/nya-bs-select": {
+      "deps": [
+        "../css/nya-bs-select.css!"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I push on PR #1001 an error, so the override was only available for the NPM version of the lib.