### PR TITLE
feat(openlayers): add openlayers which should replace the ol3 package

### DIFF
--- a/package-overrides/github/openlayers/openlayers@3.11.2.json
+++ b/package-overrides/github/openlayers/openlayers@3.11.2.json
@@ -1,0 +1,12 @@
+{
+  "main": "ol",
+  "dependencies": {
+    "css": "jspm:css@*"
+  },
+  "shim": {
+    "ol": {
+      "deps": ["./ol.css!"]
+    }
+  }
+}
+


### PR DESCRIPTION
The team behind openlayers choose to change the name of the repository, causing problem in our CI. 

The package name should be adapted