### PR TITLE
Remove @node directive from mocha

### DIFF
--- a/package-overrides/npm/mocha@3.0.0.json
+++ b/package-overrides/npm/mocha@3.0.0.json
@@ -38,11 +38,6 @@
     "mkdirp": "@empty",
     "jade": "@empty",
     "diff": "@empty",
-    "supports-color": "@empty",
-    "path": "@node/path",
-    "fs": "@node/fs",
-    "util": "@node/util",
-    "events": "@node/events",
-    "tty": "@node/tty"
+    "supports-color": "@empty"
   }
 }


### PR DESCRIPTION
Currently, [3rd party UIs](https://github.com/mochajs/mocha/wiki/Third-party-UIs) do not seem to work when using JSPM in the browser.

This is because the recommended way to build them involves `require('mocha/lib/interfaces/common')` which includes bringing in `events` and some other node modules. The overrides in the registry are causing the browser to reference node modules and everything breaks.

I assume the code deleted in the PR is there for a reason. Is there an approach to this that can allow mocha to work in both environments with a custom interface?