### PR TITLE
Fix npm:leaflet-draw missing essential files

### DIFF
--- a/package-overrides/npm/leaflet-draw@0.4.1.json
+++ b/package-overrides/npm/leaflet-draw@0.4.1.json
@@ -1,3 +1,4 @@
 {
-  "jspmNodeConversion": false
+  "jspmNodeConversion": false,
+  "files": ["dist/"]
 }


### PR DESCRIPTION
Essential files were missing from `dist/images/**/*`. Now it grabs the whole `dist/` tree.