### PR TITLE
add override for tslib to use module entry point

### DIFF
--- a/package-overrides/npm/tslib@1.0.0.json
+++ b/package-overrides/npm/tslib@1.0.0.json
@@ -1,0 +1,4 @@
+{
+  "main": "tslib.es6.js",
+  "format": "esm"
+}


### PR DESCRIPTION
Currently trying to use ```importHelpers``` option throws an error due to importing named exports from commonjs, see https://github.com/frankwallis/plugin-typescript/issues/199