### PR TITLE
fix back compatibility with jspm 0.16

### DIFF
--- a/package-overrides/npm/tslib@1.0.0.json
+++ b/package-overrides/npm/tslib@1.0.0.json
@@ -1,4 +1,4 @@
 {
-  "main": "tslib.es6.js",
-  "format": "esm"
+  "main": "tslib.js",
+  "format": "cjs"
 }


### PR DESCRIPTION
see https://github.com/Microsoft/tslib/issues/26#issuecomment-284441324

There is an issue with pointing at the ES module file because not everyone is using a transpiler.

I had to add "esModule": true to make it work with SystemJS@0.20, it seems that commonjs module.exports is hidden behind the 'default' property otherwise, which didn't seem correct to me. Shouldn't it be possible to import module.exports directly without using 'default' or setting 'esModule'?