### PR TITLE
add esModule marker for compatibility with SystemJS 0.20

### DIFF
--- a/package-overrides/npm/tslib@1.0.0.json
+++ b/package-overrides/npm/tslib@1.0.0.json
@@ -1,4 +1,9 @@
 {
   "main": "tslib.js",
-  "format": "cjs"
+  "format": "cjs",
+  "meta": {
+    "tslib.js": {
+      "esModule": true
+    }
+  }
 }


### PR DESCRIPTION
This allows for correct loading of tslib under jspm 0.17/SystemJS 0.20 while preserving compatibility with jspm 0.16/SystemJS 0.19.
See related discussion in #1040, #1041, and https://github.com/Microsoft/tslib/issues/26.

I have tested this under jspm@0.17.41 with SystemJS@0.20.10 and under jspm@0.16.53 with SystemJS@0.19.46.