### PR TITLE
fix travis ci failures due to incompatibility between dependency and specified node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '0.10'
+- '4.8.5'
 branches:
   only:
   - master


### PR DESCRIPTION
This fixes the CI failures on Travis caused by the use of hoek, a transitive dependency, that requires node >= 4.x.
This updates the node version used by the CI environment to 4.8.5.

Resolves #1064