### PR TITLE
Create utif@1.3.0.json

### DIFF
--- a/package-overrides/npm/utif@1.3.0.json
+++ b/package-overrides/npm/utif@1.3.0.json
@@ -1,0 +1,3 @@
+{
+  "jspmNodeConversion": false
+}


### PR DESCRIPTION
Because installing via JSPM throws error

Package.json dependency jpgjs set to github:notmasteryet/jpgjs, which is not a valid dependency format for npm.