### PR TITLE
socket.io-client update location of main for >2.1.1

### DIFF
--- a/package-overrides/github/socketio/socket.io-client@2.1.1
+++ b/package-overrides/github/socketio/socket.io-client@2.1.1
@@ -1,0 +1,3 @@
+{
+  "main": "dist/socket.io.js"
+}


### PR DESCRIPTION
It seems the overrides are not taken into account when the major version changes, right? Because there's already the same override for @1.7.0.