### PR TITLE
Fix files override for d3@4

### DIFF
--- a/package-overrides/npm/d3@4.11.0.json
+++ b/package-overrides/npm/d3@4.11.0.json
@@ -1,7 +1,7 @@
 {
   "main": "d3",
   "browser": "./build/d3.js",
-  "files": ["d3.js"],
+  "files": ["./build/d3.js"],
   "shim": {
     "d3": {
       "exports": "d3"


### PR DESCRIPTION
Without this change, installing `d3@4` creates a directory `d3@4.13.0` containing only a single file, `package.json`, with no script file.